### PR TITLE
Removing the amazeeio image publishing guardrail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ docker_publish_testlagoon = docker tag $(CI_BUILD_TAG)/$(1) testlagoon/$(2) && d
 docker_publish_uselagoon = docker tag $(CI_BUILD_TAG)/$(1) uselagoon/$(2) && docker push uselagoon/$(2) | cat
 
 # Tags an image with the `amazeeio` repository and pushes it
-docker_publish_amazeeio = docker tag $(CI_BUILD_TAG)/$(1) amazeeiolagoon/$(2) && docker push amazeeiolagoon/$(2) | cat
+docker_publish_amazeeio = docker tag $(CI_BUILD_TAG)/$(1) amazeeio/$(2) && docker push amazeeio/$(2) | cat
 
 #######
 ####### Base Images


### PR DESCRIPTION
This PR actually points the docker_publish_amazeeio makefile task to amazeeio dockerhub.  Once merged, tagged images will also be created in the correct namespace for legacy users.