### PR TITLE
Bump healthz-php to 0.0.6 (latest).

### DIFF
--- a/images/php-fpm/7.2.Dockerfile
+++ b/images/php-fpm/7.2.Dockerfile
@@ -3,7 +3,7 @@ FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
 FROM composer:latest as healthcheckbuilder
 
-RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.3
+RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
 FROM php:7.2.34-fpm-alpine3.11
 

--- a/images/php-fpm/7.3.Dockerfile
+++ b/images/php-fpm/7.3.Dockerfile
@@ -3,7 +3,7 @@ FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
 FROM composer:latest as healthcheckbuilder
 
-RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.3
+RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
 FROM php:7.3.24-fpm-alpine3.11
 

--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -3,7 +3,7 @@ FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
 FROM composer:latest as healthcheckbuilder
 
-RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.3
+RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
 FROM php:7.4.12-fpm-alpine3.11
 


### PR DESCRIPTION
This is what was in the [Lagoon repo](https://github.com/amazeeio/lagoon/blob/v1.9.1/images/php/fpm/Dockerfile#L9).

Fixes #32.