### PR TITLE
pin xdebug to 2.9.8 to avoid Xdebug3 b/c issues

### DIFF
--- a/images/php-fpm/7.2.Dockerfile
+++ b/images/php-fpm/7.2.Dockerfile
@@ -75,7 +75,7 @@ RUN apk add --no-cache fcgi \
         imagemagick-dev \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && yes '' | pecl install -f apcu \
-    && yes '' | pecl install -f xdebug \
+    && yes '' | pecl install -f xdebug-2.9.8 \
     && yes '' | pecl install -f yaml \
     && yes '' | pecl install -f redis-4.3.0 \
     && yes '' | pecl install -f imagick \

--- a/images/php-fpm/7.3.Dockerfile
+++ b/images/php-fpm/7.3.Dockerfile
@@ -75,7 +75,7 @@ RUN apk add --no-cache fcgi \
         imagemagick-dev \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && yes '' | pecl install -f apcu \
-    && yes '' | pecl install -f xdebug \
+    && yes '' | pecl install -f xdebug-2.9.8 \
     && yes '' | pecl install -f yaml \
     && yes '' | pecl install -f redis-4.3.0 \
     && yes '' | pecl install -f imagick \

--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -75,7 +75,7 @@ RUN apk add --no-cache fcgi \
         imagemagick-dev \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && yes '' | pecl install -f apcu \
-    && yes '' | pecl install -f xdebug \
+    && yes '' | pecl install -f xdebug-2.9.8 \
     && yes '' | pecl install -f yaml \
     && yes '' | pecl install -f redis-4.3.0 \
     && yes '' | pecl install -f imagick \


### PR DESCRIPTION
As per #40 - there a few changes in xdebug3 that should go through thorough testing prior to release.  This PR pins the xdebug version to the last known good one - 2.9.8 - whilst we test