### PR TITLE
remove duplicate dataDir entry from 7.7 solrconfig

### DIFF
--- a/images/solr-drupal/solr7.7/conf/solrconfig.xml
+++ b/images/solr-drupal/solr7.7/conf/solrconfig.xml
@@ -102,7 +102,6 @@
        replication is in use, this should match the replication
        configuration.
     -->
-  <!--<dataDir>${solr.data.dir:}</dataDir>-->
   <dataDir>/var/solr/${solr.core.name}</dataDir>
 
 


### PR DESCRIPTION
The error in https://github.com/amazeeio/lagoon/issues/2261 was identified with a dual entry in the solrconfig that we provide.  This PR removes that dual entry to stop the error.

closes https://github.com/amazeeio/lagoon/issues/2261 and supersedes https://github.com/amazeeio/lagoon/pull/2262