### PR TITLE
Updated ssmtp settings with sensible defaults

### DIFF
--- a/images/php-fpm/entrypoints/50-ssmtp.sh
+++ b/images/php-fpm/entrypoints/50-ssmtp.sh
@@ -23,12 +23,8 @@ if [ ${SSMTP_MAILHUB+x} ]; then
 elif nc -z -w 1 172.17.0.1 1025 &> /dev/null; then
   echo -e "\nmailhub=172.17.0.1:1025" >> /etc/ssmtp/ssmtp.conf
   return
-# check if mxout.lagoon.svc can do smtp TLS
-elif nc -z -w 1 mxout.lagoon.svc 465 &> /dev/null; then
-  echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf
-  return
-# Fallback: check if on Lagoon then assume mxout.lagoon.svc can do regular 25 smtp
+# Fallback: check if on Lagoon then assume mxout.lagoon.svc can do smtp TLS
 elif [[ ! -z ${LAGOON_PROJECT} ]]; then
-  echo -e "\nmailhub=mxout.lagoon.svc:25" >> /etc/ssmtp/ssmtp.conf
+  echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf
   return
 fi

--- a/images/php-fpm/entrypoints/50-ssmtp.sh
+++ b/images/php-fpm/entrypoints/50-ssmtp.sh
@@ -19,30 +19,16 @@ fi
 
 if [ ${SSMTP_MAILHUB+x} ]; then
   echo -e "\nmailhub=${SSMTP_MAILHUB}" >> /etc/ssmtp/ssmtp.conf
-else
-  # check if we find a mailhog on 172.17.0.1:1025
-  if nc -z -w 1 172.17.0.1 1025 &> /dev/null; then
-    echo -e "\nmailhub=172.17.0.1:1025" >> /etc/ssmtp/ssmtp.conf
-    return
-  fi
-  # check if mxout.lagoon.svc can do smtp TLS
-  if nc -z -w 1 mxout.lagoon.svc 465 &> /dev/null; then
-    echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf
-    return
-  fi
-  # Fallback: check if mxout.lagoon.svc can do regular 25 smtp
-  if nc -z -w 1 mxout.lagoon.svc 25 &> /dev/null; then
-    echo -e "\nmailhub=mxout.lagoon.svc:25" >> /etc/ssmtp/ssmtp.conf
-    return
-  fi
-  # check if mxout.default.svc can do smtp TLS
-  if nc -z -w 1 mxout.default.svc 465 &> /dev/null; then
-    echo -e "UseTLS=Yes\nmailhub=mxout.default.svc:465" >> /etc/ssmtp/ssmtp.conf
-    return
-  fi
-  # Fallback: check if mxout.default.svc can do regular 25 smtp
-  if nc -z -w 1 mxout.default.svc 25 &> /dev/null; then
-    echo -e "\nmailhub=mxout.default.svc:25" >> /etc/ssmtp/ssmtp.conf
-    return
-  fi
+# check if we find a mailhog on 172.17.0.1:1025
+elif nc -z -w 1 172.17.0.1 1025 &> /dev/null; then
+  echo -e "\nmailhub=172.17.0.1:1025" >> /etc/ssmtp/ssmtp.conf
+  return
+# check if mxout.lagoon.svc can do smtp TLS
+elif nc -z -w 1 mxout.lagoon.svc 465 &> /dev/null; then
+  echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf
+  return
+# Fallback: check if on Lagoon then assume mxout.lagoon.svc can do regular 25 smtp
+elif [[ ! -z ${LAGOON_PROJECT} ]]; then
+  echo -e "\nmailhub=mxout.lagoon.svc:25" >> /etc/ssmtp/ssmtp.conf
+  return
 fi

--- a/images/php-fpm/entrypoints/50-ssmtp.sh
+++ b/images/php-fpm/entrypoints/50-ssmtp.sh
@@ -24,7 +24,7 @@ elif nc -z -w 1 172.17.0.1 1025 &> /dev/null; then
   echo -e "\nmailhub=172.17.0.1:1025" >> /etc/ssmtp/ssmtp.conf
   return
 # Fallback: check if on Lagoon then assume mxout.lagoon.svc can do smtp TLS
-elif [[ ! -z ${LAGOON_PROJECT} ]]; then
+elif [ ! -z ${LAGOON_PROJECT} ]; then
   echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf
   return
 fi


### PR DESCRIPTION
This PR updates the mail configuration for the `php-fpm` container to ensure it always falls back to sensible defaults if running on Lagoon. Older, legacy ssmtp options have also been removed.