### PR TITLE
Add .sql.gz to default block list for nginx-drupal

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -27,7 +27,7 @@ server {
     ## Replicate the Apache <FilesMatch> directive of Drupal standard
     ## .htaccess. Disable access to any code files. Return a 404 to curtail
     ## information disclosure.
-    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save|\.sql|\.sql\.gz|)$ {
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save|\.sql\.gz|)$ {
       deny all;
       access_log off;
       log_not_found off;

--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -27,7 +27,7 @@ server {
     ## Replicate the Apache <FilesMatch> directive of Drupal standard
     ## .htaccess. Disable access to any code files. Return a 404 to curtail
     ## information disclosure.
-    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save|\.sql\.gz|)$ {
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|.*sql\.gz|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
       deny all;
       access_log off;
       log_not_found off;

--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -27,7 +27,7 @@ server {
     ## Replicate the Apache <FilesMatch> directive of Drupal standard
     ## .htaccess. Disable access to any code files. Return a 404 to curtail
     ## information disclosure.
-    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save|\.sql|\.sql\.gz|)$ {
       deny all;
       access_log off;
       log_not_found off;


### PR DESCRIPTION
This PR adds logic to the `nginx-drupal` image to automatiaclly block `.sql.gz` files by default.

Closes #74 