### PR TITLE
add /home/.ssh/lagoon_cli.key for root localuser only

### DIFF
--- a/images/php-cli/ssh_config
+++ b/images/php-cli/ssh_config
@@ -1,7 +1,9 @@
 Host *
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  IdentityFile /home/.ssh/lagoon_cli.key
   IdentityFile /home/.ssh/key
   ServerAliveInterval 60
   ServerAliveCountMax 1440
+
+Match localuser root
+  IdentityFile /home/.ssh/lagoon_cli.key


### PR DESCRIPTION
alternate resolution to #78 

The  /home/.ssh/lagoon_cli.key is only accessible to root users (e.g. https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/7.4.Dockerfile#L72) 

The version of openssh in use in Alpine 3.12 now errors for identityfiles in ssh_config, irregardless of whether they're needed or not - so non-root users get malformed key returns under certain circumstances.

This PR means that the lagoon_cli.key is only considered when a ssh command is run by a root localuser, removing the error message.