### PR TITLE
Adding mongodb-tools package to php-cli

### DIFF
--- a/images/php-cli/7.2.Dockerfile
+++ b/images/php-cli/7.2.Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache git \
         coreutils \
         mariadb-client \
         postgresql-client \
+        mongodb-tools \
         openssh-sftp-server \
         findutils \
         nodejs-current \

--- a/images/php-cli/7.3.Dockerfile
+++ b/images/php-cli/7.3.Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache git \
         coreutils \
         mariadb-client \
         postgresql-client \
+        mongodb-tools \
         openssh-sftp-server \
         findutils \
         nodejs-current \

--- a/images/php-cli/7.4.Dockerfile
+++ b/images/php-cli/7.4.Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache git \
         coreutils \
         mariadb-client \
         postgresql-client \
+        mongodb-tools \
         openssh-sftp-server \
         findutils \
         nodejs-current \

--- a/images/php-cli/8.0.Dockerfile
+++ b/images/php-cli/8.0.Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache git \
         coreutils \
         mariadb-client \
         postgresql-client \
+        mongodb-tools \
         openssh-sftp-server \
         findutils \
         nodejs-current \


### PR DESCRIPTION
This PR adds the `mongodb-tools` package to the php-cli container, which enables the backup and restoration of mongodb from within this container.