### PR TITLE
Added support for injecting Matomo snippets via ngx_http_sub_module.

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -44,6 +44,7 @@ RUN mkdir -p /app \
     && fix-permissions /var/run/
 
 COPY docker-entrypoint /lagoon/entrypoints/70-nginx-entrypoint
+COPY matomo/80-nginx-matomo-config /lagoon/entrypoints/
 
 WORKDIR /app
 

--- a/images/nginx/matomo/80-nginx-matomo-config
+++ b/images/nginx/matomo/80-nginx-matomo-config
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Inject Matomo tracking snippets via nginx configuration.
+
+# Single site configuration.
+if [ "$MATOMO_URL" ]; then
+
+    # Add Matomo tracking code to end of the HEAD section.
+    cat <<EOF >> /etc/nginx/conf.d/matomo.conf
+sub_filter '</head>'
+"<!-- Matomo -->
+<script type='text/javascript'>
+var _paq = window._paq = window._paq || [];
+/* tracker methods like 'setCustomDimension' should be called before 'trackPageView' */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+    var u='${MATOMO_URL}';
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '${MATOMO_SITE_ID:-1}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();
+</script>
+<!-- End Matomo Code -->
+</head>";
+sub_filter_once on;
+EOF
+
+fi
+
+# Tag manager configuration.
+if [ "$MATOMO_TAG_MANAGER_URL" ]; then
+
+    cat <<EOF >> /etc/nginx/conf.d/matomo.conf
+sub_filter '<head>'
+"<head>
+<!-- Matomo Tag Manager -->
+<script type='text/javascript'>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.type='text/javascript'; g.async=true; g.src='${MATOMO_TAG_MANAGER_URL}'; s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->";
+sub_filter_once on;
+EOF
+
+fi

--- a/images/nginx/matomo/README.md
+++ b/images/nginx/matomo/README.md
@@ -1,0 +1,18 @@
+# Matomo
+
+Allows automatic injection of Matomo tracking snippets via environment varibales using ngx_http_sub_module.
+Snippets are only included when one following configurations have been enabled:
+
+## Single site
+
+`MATOMO_URL` (required) - URL to the Matomo instance.
+`MATOMO_SITE_ID` (required) - Matomo Site ID.
+
+Both environment variable are required to be set.
+Matomo tracking code is injected before the end of the HEAD section of all html reponses.
+
+## Tag manager
+
+`MATOMO_TAG_MANAGER_URL` (required) - URL of the container JS file eg. https://[matomo-url]/js/container_xxxxxxxx.js
+
+Matomo tracking code is injected at the start of the HEAD section of all html reponses.


### PR DESCRIPTION
Adds an entrypoint script to the base `nginx` image which will generate new NGINX configuration file that injects Matomo tracking snippets. There's 2 different options - a standard installation which requires a Matomo URL `MATOMO_URL` and Site ID `MATOMO_SITE_ID` the other option is providing a URL `MATOMO_TAG_MANAGER_URL` to a Tag manager script that will allow the use of Matomo Tag manager.

If no variables are set no config files are created and there's no affect to the current default behaviours.

# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

# Closing issues
closes #95