### PR TITLE
Adding redis-cli and psql to Toolbox image

### DIFF
--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache curl ncdu socat ca-certificates openssl perl perl-doc mysql-client rsync mariadb-mytop \
+    && apk add --no-cache curl ncdu socat ca-certificates openssl perl perl-doc mysql-client rsync mariadb-mytop redis postgresql-client \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/* \
     && wget https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -O mysqltuner.pl \


### PR DESCRIPTION
This PR adds both the `redis-cli` and `psql` binaries to the toolbox images, allowing us to connect to these resources using this same image as well.