### PR TITLE
add Python 3.9 base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ versioned-images := 		php-7.2-fpm \
 							python-2.7 \
 							python-3.7 \
 							python-3.8 \
+							python-3.9 \
 							python-2.7-ckan \
 							python-2.7-ckandatapusher \
 							node-10 \
@@ -225,7 +226,7 @@ build/php-7.2-cli-drupal: build/php-7.2-cli
 build/php-7.3-cli-drupal: build/php-7.3-cli
 build/php-7.4-cli-drupal: build/php-7.4-cli
 build/php-8.0-cli-drupal: build/php-8.0-cli
-build/python-2.7 build/python-3.7 build/python-3.8: build/commons
+build/python-2.7 build/python-3.7 build/python-3.8 build/python-3.9: build/commons
 build/python-2.7-ckan: build/python-2.7
 build/python-2.7-ckandatapusher: build/python-2.7
 build/node-10 build/node-12 build/node-14 build/node-16: build/commons

--- a/images/python/3.9.Dockerfile
+++ b/images/python/3.9.Dockerfile
@@ -1,0 +1,39 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+
+FROM python:3.9.4-alpine3.13
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=python
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+RUN apk add --no-cache --virtual .build-deps \
+      build-base \
+    && pip install --upgrade pip \
+    && pip install virtualenv \
+    && apk del .build-deps
+
+# Make sure shells are not running forever
+COPY 80-shell-timeout.sh /lagoon/entrypoints/
+RUN echo "source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["python"]


### PR DESCRIPTION
This PR adds support for Python 3.9.

It also removes the pin on virtualenv 16.