### PR TITLE
Adding tar to all images

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=builder /go/bin/go-crond /lagoon/bin/cron
 
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache curl tini \
+    && apk add --no-cache curl tini tar \
     && rm -rf /var/cache/apk/* \
     && curl -sLo /bin/ep https://github.com/kreuzwerker/envplate/releases/download/1.0.0-RC1/ep-linux \
     && echo "48e234e067874a57a4d4bb198b5558d483ee37bcc285287fffb3864818b42f2785be0568faacbc054e97ca1c5047ec70382e1ca0e71182c9dba06649ad83a5f6  /bin/ep" | sha512sum -c \

--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -45,6 +45,7 @@ RUN \
     tzdata \
     wget \
     gettext; \
+    tar \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
     rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
     curl -sSL http://mysqltuner.pl/ -o mysqltuner.pl

--- a/images/mongo/Dockerfile
+++ b/images/mongo/Dockerfile
@@ -23,7 +23,7 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk --no-cache add mongodb
+RUN apk --no-cache add mongodb tar
 
 RUN mkdir -p /data/db /data/configdb && \
     fix-permissions /data/db && \

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -28,7 +28,7 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl tar
 
 RUN rm -Rf /etc/nginx && ln -s /usr/local/openresty/nginx/conf /etc/nginx
 

--- a/images/node/10.Dockerfile
+++ b/images/node/10.Dockerfile
@@ -32,6 +32,7 @@ ENV TMPDIR=/tmp \
 
 RUN apk update \
     && apk upgrade \
+    && apk add --no-cache tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root

--- a/images/node/12.Dockerfile
+++ b/images/node/12.Dockerfile
@@ -32,6 +32,7 @@ ENV TMPDIR=/tmp \
 
 RUN apk update \
     && apk upgrade \
+    && apk add --no-cache tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root

--- a/images/node/14.Dockerfile
+++ b/images/node/14.Dockerfile
@@ -32,6 +32,7 @@ ENV TMPDIR=/tmp \
 
 RUN apk update \
     && apk upgrade \
+    && apk add --no-cache tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root

--- a/images/node/16.Dockerfile
+++ b/images/node/16.Dockerfile
@@ -32,6 +32,7 @@ ENV TMPDIR=/tmp \
 
 RUN apk update \
     && apk upgrade \
+    && apk add --no-cache tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root

--- a/images/php-fpm/7.2.Dockerfile
+++ b/images/php-fpm/7.2.Dockerfile
@@ -52,6 +52,7 @@ ENV NEWRELIC_VERSION=9.17.0.300
 
 RUN apk add --no-cache fcgi \
         ssmtp \
+        tar \
         libzip libzip-dev \
         # for gd
         libpng-dev \

--- a/images/php-fpm/7.3.Dockerfile
+++ b/images/php-fpm/7.3.Dockerfile
@@ -52,6 +52,7 @@ ENV NEWRELIC_VERSION=9.17.0.300
 
 RUN apk add --no-cache fcgi \
         ssmtp \
+        tar \
         libzip libzip-dev \
         # for gd
         libpng-dev \

--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -52,6 +52,7 @@ ENV NEWRELIC_VERSION=9.17.0.300
 
 RUN apk add --no-cache fcgi \
         ssmtp \
+        tar \
         libzip libzip-dev \
         # for gd
         libpng-dev \

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -54,6 +54,7 @@ RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/m
 
 RUN apk add --no-cache fcgi \
         ssmtp \
+        tar \
         libzip libzip-dev \
         # for gd
         libpng-dev \

--- a/images/postgres/11.Dockerfile
+++ b/images/postgres/11.Dockerfile
@@ -26,6 +26,9 @@ ENV TMPDIR=/tmp \
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 
+RUN apk update \
+    && apk add --no-cache tar
+
 ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/

--- a/images/postgres/12.Dockerfile
+++ b/images/postgres/12.Dockerfile
@@ -26,6 +26,9 @@ ENV TMPDIR=/tmp \
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 
+RUN apk update \
+    && apk add --no-cache tar
+
 ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/

--- a/images/python/2.7.Dockerfile
+++ b/images/python/2.7.Dockerfile
@@ -25,7 +25,7 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache --virtual .build-deps \
-      build-base \
+      build-base tar \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del .build-deps

--- a/images/python/2.7.Dockerfile
+++ b/images/python/2.7.Dockerfile
@@ -25,10 +25,12 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache --virtual .build-deps \
-      build-base tar \
+      build-base \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del .build-deps
+
+RUN apk add --no-cache tar
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.7.Dockerfile
+++ b/images/python/3.7.Dockerfile
@@ -25,7 +25,7 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache --virtual .build-deps \
-      build-base \
+      build-base tar \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del .build-deps

--- a/images/python/3.7.Dockerfile
+++ b/images/python/3.7.Dockerfile
@@ -25,10 +25,12 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache --virtual .build-deps \
-      build-base tar \
+      build-base \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del .build-deps
+
+RUN apk add --no-cache tar
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -26,7 +26,7 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache --virtual .build-deps \
-      build-base \
+      build-base tar \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del .build-deps

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -26,10 +26,12 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk add --no-cache --virtual .build-deps \
-      build-base tar \
+      build-base \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del .build-deps
+
+RUN apk add --no-cache tar
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/redis/5.Dockerfile
+++ b/images/redis/5.Dockerfile
@@ -28,6 +28,9 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache tar
+
 COPY conf /etc/redis/
 COPY docker-entrypoint /lagoon/entrypoints/70-redis-entrypoint
 

--- a/images/redis/6.Dockerfile
+++ b/images/redis/6.Dockerfile
@@ -28,6 +28,9 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache tar
+
 COPY conf /etc/redis/
 COPY docker-entrypoint /lagoon/entrypoints/70-redis-entrypoint
 

--- a/images/solr/5.5.Dockerfile
+++ b/images/solr/5.5.Dockerfile
@@ -33,6 +33,8 @@ RUN fix-permissions /var/solr \
     && fix-permissions /opt/solr/server/logs \
     && fix-permissions /opt/solr/server/solr
 
+RUN apk update \
+    && apk add --no-cache tar
 
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr

--- a/images/solr/6.6.Dockerfile
+++ b/images/solr/6.6.Dockerfile
@@ -33,6 +33,8 @@ RUN fix-permissions /var/solr \
     && fix-permissions /opt/solr/server/logs \
     && fix-permissions /opt/solr/server/solr
 
+RUN apk update \
+    && apk add --no-cache tar
 
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr

--- a/images/solr/7.7.Dockerfile
+++ b/images/solr/7.7.Dockerfile
@@ -33,6 +33,8 @@ RUN fix-permissions /var/solr \
     && fix-permissions /opt/solr/server/logs \
     && fix-permissions /opt/solr/server/solr
 
+RUN apk update \
+    && apk add --no-cache tar
 
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -31,7 +31,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin
 USER root
 
 RUN apt-get -y update && apt-get -y install \
-    busybox \
+    busybox tar \
     && rm -rf /var/lib/apt/lists/*
 
 # needed to fix dash upgrade - man files are removed from slim images

--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache curl ncdu socat ca-certificates openssl perl perl-doc mysql-client rsync mariadb-mytop redis postgresql-client \
+    && apk add --no-cache curl ncdu socat ca-certificates openssl perl perl-doc mysql-client rsync mariadb-mytop redis postgresql-client tar \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/* \
     && wget https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -O mysqltuner.pl \

--- a/images/varnish/5.Dockerfile
+++ b/images/varnish/5.Dockerfile
@@ -4,7 +4,7 @@ FROM ${IMAGE_REPO:-lagoon}/commons as commons
 FROM alpine:3.7 as vmod
 ENV LIBVMOD_DYNAMIC_VERSION=5.2
 ENV LIBVMOD_BODYACCESS_VERSION=5.0
-RUN apk --no-cache add varnish varnish-dev automake autoconf libtool python py-docutils make curl
+RUN apk --no-cache add varnish varnish-dev automake autoconf libtool python py-docutils make curl tar
 
 RUN cd /tmp && curl -sSLO https://github.com/nigoroll/libvmod-dynamic/archive/${LIBVMOD_DYNAMIC_VERSION}.zip && \
   unzip ${LIBVMOD_DYNAMIC_VERSION}.zip && cd libvmod-dynamic-${LIBVMOD_DYNAMIC_VERSION} && \

--- a/images/varnish/6.Dockerfile
+++ b/images/varnish/6.Dockerfile
@@ -4,7 +4,7 @@ FROM ${IMAGE_REPO:-lagoon}/commons as commons
 FROM varnish:6.5 as vmod
 ENV LIBVMOD_DYNAMIC_VERSION=6.5
 ENV VARNISH_MODULES_VERSION=6.5
-RUN apt-get update && apt-get -y install build-essential automake libtool python-docutils libpcre3-dev varnish-dev curl zip
+RUN apt-get update && apt-get -y install build-essential automake libtool python-docutils libpcre3-dev varnish-dev curl zip tar
 
 RUN cd /tmp && curl -sSLO https://github.com/nigoroll/libvmod-dynamic/archive/${LIBVMOD_DYNAMIC_VERSION}.zip && \
   unzip ${LIBVMOD_DYNAMIC_VERSION}.zip && cd libvmod-dynamic-${LIBVMOD_DYNAMIC_VERSION} && \


### PR DESCRIPTION
This PR adds GNU `tar` to all images where it makes sense to have it. This provides us with compatibility for the `--exclude` flag, which busybox's `tar` binary does not have support for. 

Closes #169 