### PR TITLE
use upstream multi-arch docker image for go-crond

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -1,8 +1,4 @@
-FROM golang:alpine3.12 AS builder
-RUN GIT_TAG=github.com/smlx/go-crond@custom-workdir-mod-update GIT_COMMIT=1b81c05ef34903427ed06a56c26cc268a0377b83; \
-    GO111MODULE=on CGO_ENABLED=0 go get -ldflags "-X main.gitTag=$GIT_TAG -X main.gitCommit=$GIT_COMMIT" \
-    github.com/smlx/go-crond@$GIT_COMMIT
-
+FROM webdevops/go-crond:21.5.0-alpine AS go-crond
 FROM alpine:3.12.7
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
@@ -15,7 +11,7 @@ RUN mkdir -p /lagoon/bin
 COPY fix-permissions docker-sleep entrypoint-readiness wait-for /bin/
 COPY .bashrc /home/.bashrc
 
-COPY --from=builder /go/bin/go-crond /lagoon/bin/cron
+COPY --from=go-crond /usr/local/bin/go-crond /lagoon/bin/cron
 
 RUN apk update \
     && apk upgrade \


### PR DESCRIPTION
Now that https://github.com/webdevops/go-crond/pull/21 has been merged, we can again use the upstream go-crond.

This PR uses their published docker image for the binary - looking to make as many binary components of Lagoon as multi-arch as possible.