### PR TITLE
version mariadb images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ build/commons: images/commons/Dockerfile
 build/mongo: build/commons images/mongo/Dockerfile
 build/nginx: build/commons images/nginx/Dockerfile
 build/nginx-drupal: build/nginx images/nginx-drupal/Dockerfile
-build/toolbox: build/commons build/mariadb images/toolbox/Dockerfile
+build/toolbox: build/commons build/mariadb-10.5 images/toolbox/Dockerfile
 
 #######
 ####### Multi-version Images

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,6 @@ docker_publish_amazeeio = docker tag $(CI_BUILD_TAG)/$(1) amazeeio/$(2) && docke
 ####### Base Images are the base for all other images and are also published for clients to use during local development
 
 unversioned-images :=		commons \
-							mariadb \
-							mariadb-drupal \
 							mongo \
 							nginx \
 							nginx-drupal \
@@ -119,8 +117,6 @@ $(build-images):
 # 2. Dockerfiles of the Images itself, will cause make to rebuild the images if something has
 #    changed on the Dockerfiles
 build/commons: images/commons/Dockerfile
-build/mariadb: build/commons images/mariadb/Dockerfile
-build/mariadb-drupal: build/mariadb images/mariadb-drupal/Dockerfile
 build/mongo: build/commons images/mongo/Dockerfile
 build/nginx: build/commons images/nginx/Dockerfile
 build/nginx-drupal: build/nginx images/nginx-drupal/Dockerfile
@@ -178,11 +174,15 @@ versioned-images := 		php-7.2-fpm \
 							varnish-6-persistent \
 							varnish-6-persistent-drupal \
 							solr-7 \
-							solr-7-drupal
+							solr-7-drupal \
+							mariadb-10.5 \
+							mariadb-10.5-drupal \
 
 # newly-versioned-images are images that formerly had no versioning, and are made backwards-compatible.
 
-newly-versioned-images := 	postgres-11 \
+newly-versioned-images := 	mariadb-10.4 \
+							mariadb-10.4-drupal \
+							postgres-11 \
 							postgres-11-ckan \
 							postgres-11-drupal \
 							redis-5 \
@@ -245,7 +245,6 @@ build/postgres-11 build/postgres-12: build/commons
 build/postgres-11-ckan build/postgres-11-drupal: build/postgres-11
 build/redis-5 build/redis-6: build/commons
 build/redis-5-persistent: build/redis-5
-build/redis-5 build/redis-6: build/commons
 build/redis-6-persistent: build/redis-6
 build/varnish-5 build/varnish-6: build/commons
 build/varnish-5-drupal build/varnish-5-persistent: build/varnish-5
@@ -254,6 +253,9 @@ build/varnish-6-drupal build/varnish-6-persistent: build/varnish-6
 build/varnish-6-persistent-drupal: build/varnish-6-drupal
 build/solr-7: build/commons
 build/solr-7-drupal: build/solr-7
+build/mariadb-10.4 build/mariadb-10.5: build/commons
+build/mariadb-10.4-drupal: build/mariadb-10.4
+build/mariadb-10.5-drupal: build/mariadb-10.5
 
 #######
 ####### Building Images

--- a/images/mariadb-drupal/10.4.Dockerfile
+++ b/images/mariadb-drupal/10.4.Dockerfile
@@ -1,0 +1,9 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/mariadb-10.4
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV MARIADB_DATABASE=drupal \
+    MARIADB_USER=drupal \
+    MARIADB_PASSWORD=drupal

--- a/images/mariadb-drupal/10.5.Dockerfile
+++ b/images/mariadb-drupal/10.5.Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/mariadb
+FROM ${IMAGE_REPO:-lagoon}/mariadb-10.5
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -36,10 +36,10 @@ RUN \
     apk add --no-cache --virtual .common-run-deps \
     bash \
     curl \
-    mariadb \
-    mariadb-client \
-    mariadb-common \
-    mariadb-server-utils \
+    mariadb=~10.4 \
+    mariadb-client=~10.4 \
+    mariadb-common=~10.4 \
+    mariadb-server-utils=~10.4 \
     net-tools \
     pwgen \
     tzdata \

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -1,0 +1,78 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM alpine:3.13.5
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+ENV BACKUPS_DIR="/var/lib/mysql/backup"
+
+ENV MARIADB_DATABASE=lagoon \
+    MARIADB_USER=lagoon \
+    MARIADB_PASSWORD=lagoon \
+    MARIADB_ROOT_PASSWORD=Lag00n
+
+RUN \
+    apk add --no-cache --virtual .common-run-deps \
+    bash \
+    curl \
+    mariadb=~10.5 \
+    mariadb-client=~10.5 \
+    mariadb-common=~10.5 \
+    mariadb-server-utils=~10.5 \
+    net-tools \
+    pwgen \
+    tzdata \
+    wget \
+    gettext; \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
+    rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
+    curl -sSL http://mysqltuner.pl/ -o mysqltuner.pl
+
+COPY entrypoints/ /lagoon/entrypoints/
+COPY mysql-backup.sh /lagoon/
+COPY my.cnf /etc/mysql/my.cnf
+
+RUN for i in /var/run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d/ "${BACKUPS_DIR}" /home; \
+    do mkdir -p $i; chown mysql $i; /bin/fix-permissions $i; \
+    done
+
+COPY root/usr/share/container-scripts/mysql/readiness-probe.sh /usr/share/container-scripts/mysql/readiness-probe.sh
+RUN /bin/fix-permissions /usr/share/container-scripts/mysql/ \
+    && /bin/fix-permissions /etc/mysql
+
+RUN touch /var/log/mariadb-slow.log && /bin/fix-permissions /var/log/mariadb-slow.log \
+    && touch /var/log/mariadb-queries.log && /bin/fix-permissions /var/log/mariadb-queries.log
+
+# We cannot start mysql as root, we add the user mysql to the group root and
+# change the user of the Docker Image to this user.
+RUN addgroup mysql root
+USER mysql
+ENV USER_NAME mysql
+
+WORKDIR /var/lib/mysql
+VOLUME /var/lib/mysql
+EXPOSE 3306
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+CMD ["mysqld"]

--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 
-FROM ${IMAGE_REPO:-lagoon}/mariadb as mariadb
+FROM ${IMAGE_REPO:-lagoon}/mariadb-10.5 as mariadb
 
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 


### PR DESCRIPTION
This PR adds version numbers to the mariadb images.

Given they release a minor version annually (https://mariadb.com/kb/en/mariadb-server/), it makes sense to pin there.

The current release `uselagoon/mariadb` is equivalent to `uselagoon/mariadb-10.4`
