### PR TITLE
Fail image build if composer checksum does not match.

### DIFF
--- a/images/php-cli/7.2.Dockerfile
+++ b/images/php-cli/7.2.Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache git \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
-    && echo "$COMPOSER_HASH_SHA256 /usr/local/bin/composer" | sha256sum \
+    && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
     && php -d memory_limit=-1 /usr/local/bin/composer global require hirak/prestissimo \
     && mkdir -p /home/.ssh \

--- a/images/php-cli/7.3.Dockerfile
+++ b/images/php-cli/7.3.Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache git \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
-    && echo "$COMPOSER_HASH_SHA256 /usr/local/bin/composer" | sha256sum \
+    && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
     && php -d memory_limit=-1 /usr/local/bin/composer global require hirak/prestissimo \
     && mkdir -p /home/.ssh \

--- a/images/php-cli/7.4.Dockerfile
+++ b/images/php-cli/7.4.Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache git \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
-    && echo "$COMPOSER_HASH_SHA256 /usr/local/bin/composer" | sha256sum \
+    && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
     && php -d memory_limit=-1 /usr/local/bin/composer global require hirak/prestissimo \
     && mkdir -p /home/.ssh \

--- a/images/php-cli/Dockerfile
+++ b/images/php-cli/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache git \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
-    && echo "$COMPOSER_HASH_SHA256 /usr/local/bin/composer" | sha256sum \
+    && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
     && php -d memory_limit=-1 /usr/local/bin/composer global require hirak/prestissimo \
     && mkdir -p /home/.ssh \


### PR DESCRIPTION
This change ensures the image build fails when the downloaded composer does not match the SHA256 hash.

The current syntax does not actually check whether the hash is correct and always passes, even if the hash does not match. It can be proven by changing a digit in the `COMPOSER_HASH_SHA256` variable and building the image.