### PR TITLE
Add support for caching when behind the amazee.io no-cache CDN.

### DIFF
--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -58,6 +58,11 @@ sub vcl_recv {
     set req.http.X-LAGOON-VARNISH = "${HOSTNAME}-${LAGOON_GIT_BRANCH:-undef}-${LAGOON_PROJECT}, " + req.http.X-LAGOON-VARNISH;
     set req.http.X-LAGOON-VARNISH-BYPASS = "true";
   }
+  else if (req.http.X-AMAZEEIO-NO-CACHE-CDN) {
+    # Do no pass for requests from the no-cache CDN.
+    set req.http.X-LAGOON-VARNISH = "${HOSTNAME}-${LAGOON_GIT_BRANCH:-undef}-${LAGOON_PROJECT}, amazeeio-no-cache-cdn";
+    set req.http.X-LAGOON-VARNISH-BYPASS = "false";
+  }
   else if (req.http.Fastly-FF) {
     # Pass all Requests which are handled via Fastly
     set req.http.X-LAGOON-VARNISH = "${HOSTNAME}-${LAGOON_GIT_BRANCH:-undef}-${LAGOON_PROJECT}, fastly";

--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -93,7 +93,7 @@ sub vcl_recv {
     return (pipe);
   }
 
-  if (req.http.X-LAGOON-VARNISH-BYPASS == "true" || req.http.X-LAGOON-VARNISH-BYPASS == "TRUE") {
+  if (req.http.X-LAGOON-VARNISH-BYPASS ~ "(?i)true") {
     return (pass);
   }
 

--- a/images/varnish-drupal/drupal.vcl
+++ b/images/varnish-drupal/drupal.vcl
@@ -105,10 +105,10 @@ sub vcl_recv {
   # Strip out Google Analytics campaign variables. They are only needed
   # by the javascript running on the page
   # utm_source, utm_medium, utm_campaign, gclid
-   if(req.url ~ "(\?|&)(gclid|utm_[a-z]+)=") {
-     set req.url = regsuball(req.url, "(gclid|utm_[a-z]+)=[^\&]+&?", "");
-     set req.url = regsub(req.url, "(\?|&)$", "");
-   }
+  if (req.url ~ "(\?|&)(gclid|utm_[a-z]+)=") {
+    set req.url = regsuball(req.url, "(gclid|utm_[a-z]+)=[^\&]+&?", "");
+    set req.url = regsub(req.url, "(\?|&)$", "");
+  }
 
   # Bypass a cache hit (the request is still sent to the backend)
   if (req.method == "REFRESH") {
@@ -159,7 +159,7 @@ sub vcl_recv {
     req.method != "TRACE" &&
     req.method != "OPTIONS" &&
     req.method != "DELETE") {
-     return (pipe);
+      return (pipe);
   }
 
   # Large binary files are passed.


### PR DESCRIPTION
amazee.io maintains a number of no-cache CDN options for customers. At present, with the detection of Fastly being in front, this disables all caching. This is not ideal.

This PR brings with it the use of an additional header to which these Fastly services will add. Thus we can enable caching again.