### PR TITLE
add docker_pull command to Makefile to pull fresh upstream images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ node ('lagoon-images') {
 
         stage ('build images') {
           env.SCAN_IMAGES = 'true'
+          sh script: "make docker_pull", label: "Ensuring fresh upstream images"
           sh script: "make -O${SYNC_MAKE_OUTPUT} -j8 build", label: "Building images"
         }
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ docker_publish_uselagoon = docker tag $(CI_BUILD_TAG)/$(1) uselagoon/$(2) && doc
 # Tags an image with the `amazeeio` repository and pushes it
 docker_publish_amazeeio = docker tag $(CI_BUILD_TAG)/$(1) amazeeio/$(2) && docker push amazeeio/$(2) | cat
 
+.PHONY: docker_pull
+docker_pull:
+	grep -Eh 'FROM' $$(find . -type f -name *Dockerfile) | grep -Ev 'IMAGE_REPO' | awk '{print $$2}' | sort --unique | xargs -tn1 -P8 docker pull -q
+
 #######
 ####### Base Images
 #######


### PR DESCRIPTION
This PR adds a Makefile command to search through the repo for all upstream dockerfiles, and then perform a `docker pull` on these images to ensure that the images are being built using the latest images.

This will automatically occur in Jenkins, but can be run manually locally.