### PR TITLE
Add in PECL packages to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,87 @@
   "separateMajorMinor": true,
   "separateMinorPatch": true,
   "separateMultipleMajor": true,
-  "packageRules": [
+  "regexManagers": [
     {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["pecl install -f apcu-(?<currentValue>.*?) "],
+      "depNameTemplate": "krakjoe/apcu",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["pecl install -f imagick-(?<currentValue>.*?) "],
+      "depNameTemplate": "Imagick/imagick",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["pecl install -f redis-(?<currentValue>.*?) "],
+      "depNameTemplate": "phpredis/phpredis",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["pecl install -f xdebug-(?<currentValue>.*?) "],
+      "depNameTemplate": "xdebug/xdebug",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["pecl install -f yaml-(?<currentValue>.*?) "],
+      "depNameTemplate": "php/pecl-file_formats-yaml",
+      "datasourceTemplate": "github-tags"
+    }
+  ],
+  "packageRules": [
+    { 
+      "enabled": true,
+      "matchDatasources": [
+        "github-releases",
+        "github-tags"
+      ],
+      "matchPackageNames": [
+        "krakjoe/apcu"
+      ],
+      "extractVersion": "^v(?<version>.*)$"
+    },
+    { 
+      "enabled": true,
+      "matchDatasources": [
+        "github-releases",
+        "github-tags"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchPackageNames": [
+        "Imagick/imagick",
+        "phpredis/phpredis",
+        "xdebug/xdebug",
+        "php/pecl-file_formats-yaml"
+      ]
+    },
+    { 
+      "enabled": false,
+      "groupName": "Disable PECL major updates",
+      "matchDatasources": [
+        "github-releases",
+        "github-tags"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchPackageNames": [
+        "krakjoe/apcu",
+        "Imagick/imagick",
+        "phpredis/phpredis",
+        "xdebug/xdebug",
+        "php/pecl-file_formats-yaml"
+      ]
+    },
+    {
+      "enabled": true,
       "matchDatasources": [
         "docker"
       ],
@@ -42,6 +121,7 @@
       ]
     },
     {
+      "enabled": true,
       "matchDatasources": [
         "docker"
       ],


### PR DESCRIPTION
This PR adds the PECL packages consumed by the PHP images to the renovate.json

This allows Renovate to suggest updates to packages as they are released onto PECL.

It does this by scanning the package source github repos for releases, but has been instructed to ignore major version bumps (i.e. Redis 4>5 and Xdebug 3>4)