### PR TITLE
PROCESS privilege and cache in dump

### DIFF
--- a/images/php-cli-drupal/drush.yml
+++ b/images/php-cli-drupal/drush.yml
@@ -4,3 +4,12 @@
 options:
   root: '/app/${env.WEBROOT}'
   uri: '${env.LAGOON_ROUTE}'
+  
+command:
+  sql:
+    dump:
+      options:
+        # Omit cache and similar tables (including during a sql:sync).
+        structure-tables-key: common
+        # Do not write any CREATE LOGFILE GROUP or CREATE TABLESPACE statements in output.
+        extra-dump: --no-tablespaces


### PR DESCRIPTION
Running `drush sql:dump` PROCESS error is observed when interacting with Lagoon mariadb images.

The issue is more cosmetic.
It will output the sql, but show an ugly error.

```bash
[client-drupal]master@cli-drupal:/app$ drush sql:dump > test.sql
> mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces
[client-drupal]master@cli-drupal:/app$ 

...

-rw-rw-r--  1 root root 9974048 Sep 23 06:31 test.sql
```

Problems exist upstream with tools that control the drush statement (lando, ahoy)

https://github.com/lando/cli/blob/d202e5cd7c5c09b9b124da8179578ef8bfe47e3e/integrations/lando-lagoon/scripts/lagoon-pull.sh#L149

Issue ref:
https://github.com/drush-ops/drush/issues/4489

Similar issues:
https://github.com/govCMS/scaffold-tooling/issues/96


