### PR TITLE
Remove hirak/prestissimo from global dependencies

### DIFF
--- a/images/php-cli/7.3.Dockerfile
+++ b/images/php-cli/7.3.Dockerfile
@@ -33,7 +33,6 @@ RUN apk add --no-cache git \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
     && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
-    && php -d memory_limit=-1 /usr/local/bin/composer global require hirak/prestissimo \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 

--- a/images/php-cli/7.4.Dockerfile
+++ b/images/php-cli/7.4.Dockerfile
@@ -33,7 +33,6 @@ RUN apk add --no-cache git \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
     && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
-    && php -d memory_limit=-1 /usr/local/bin/composer global require hirak/prestissimo \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 


### PR DESCRIPTION
Because it is not compatible with Composer 2. Projects that are still using Composer 1 (WHY?) should install it as a project-level dependency.

# Problem

```
[project-fooo]master@cli-drupal:/app$ composer --version
Composer version 2.1.11 2021-11-02 12:10:25
[project-fooo]master@cli-drupal:/app$ composer install
The "hirak/prestissimo" plugin (installed globally) was skipped because it requires a Plugin API version ("^1.0.0") that does not match your Composer installation ("2.1.0"). You may need to run composer update with the "--no-plugins" option.
```

As [it was suggested](https://github.com/uselagoon/lagoon-images/issues/265#issuecomment-763027786) in the main Composer 2 update issue, we (and others) updated projects to Composer 2 on the downstream by modifying Dockerfile.php. The problem is that the upstream image installs a Composer plugin globally that is not compatible with Composer 2 (and its maintainer is [not answering the community request ](https://github.com/hirak/prestissimo/issues/233) for "faking it as compatible" and making the transition from Composer 1 to 2 easier).