### PR TITLE
use official openresty package image instead of source image

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 # Alpine 3.12 per https://github.com/openresty/docker-openresty/blob/1.19.3.1-0/alpine/Dockerfile
-FROM openresty/openresty:1.19.9.1-alpine
+FROM openresty/openresty:1.19.9.1-alpine-apk
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
As per https://github.com/openresty/docker-openresty there is now an alpine-apk image for openresty, built from the upstream package instead of built from source.