### PR TITLE
change to "varnish" user as per upstream for varnish-6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ SHELL := /bin/bash
 #######
 
 # Parameter for all `docker build` commands, can be overwritten by passing `DOCKER_BUILD_PARAMS=` via the `-e` option
-DOCKER_BUILD_PARAMS :=
+DOCKER_BUILD_PARAMS := --quiet
 
 # On CI systems like jenkins we need a way to run multiple testings at the same time. We expect the
 # CI systems to define an Environment variable CI_BUILD_TAG which uniquely identifies each build.

--- a/images/varnish-drupal/6.Dockerfile
+++ b/images/varnish-drupal/6.Dockerfile
@@ -4,6 +4,9 @@ FROM ${IMAGE_REPO:-lagoon}/varnish-6
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
-COPY drupal.vcl /etc/varnish/default.vcl
+USER root
 
+COPY drupal.vcl /etc/varnish/default.vcl
 RUN fix-permissions /etc/varnish/default.vcl
+
+USER varnish

--- a/images/varnish/6.Dockerfile
+++ b/images/varnish/6.Dockerfile
@@ -4,6 +4,8 @@ FROM ${IMAGE_REPO:-lagoon}/commons as commons
 FROM varnish:6.6 as vmod
 ENV LIBVMOD_DYNAMIC_VERSION=6.6
 ENV VARNISH_MODULES_VERSION=6.6
+
+USER root
 RUN apt-get update && apt-get -y install build-essential curl zip
 
 RUN  curl -L https://packagecloud.io/varnishcache/varnish66/gpgkey | apt-key add - \
@@ -42,6 +44,7 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+USER root
 RUN apt-get -y update && apt-get -y install \
     busybox \
     curl \
@@ -73,6 +76,8 @@ RUN fix-permissions /etc/varnish/ \
     && fix-permissions /var/lib/varnish
 
 COPY docker-entrypoint /lagoon/entrypoints/70-varnish-entrypoint
+
+USER varnish
 
 EXPOSE 8080
 


### PR DESCRIPTION
Upstream varnish has [recently](https://github.com/varnish/docker-varnish/commit/9bbe2f325934f00ee5506c956e4883f3a8e6884e) moved to running varnish as an unprivileged user

To make this work, I have had to wrap the install, copy and fix-permission commands in a `USER root`, resetting it back to `USER varnish` afterwards