### PR TITLE
Adding SOLR_OPTS, LS_JAVA_OPTS, and ES_JAVA_OPTS to patch against CVE-2021-44228

### DIFF
--- a/images/elasticsearch/6.Dockerfile
+++ b/images/elasticsearch/6.Dockerfile
@@ -46,7 +46,7 @@ discovery.zen.minimum_master_nodes: "${DISCOVERY_ZEN_MINIMUM_MASTER_NODES}"' >> 
 
 RUN fix-permissions config
 
-ENV ES_JAVA_OPTS="-Xms400m -Xmx400m" \
+ENV ES_JAVA_OPTS="-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true" \
     DISCOVERY_ZEN_MINIMUM_MASTER_NODES=1 \
     NODE_MASTER=true
 

--- a/images/elasticsearch/7.Dockerfile
+++ b/images/elasticsearch/7.Dockerfile
@@ -50,7 +50,7 @@ cluster.remote.connect: "${CLUSTER_REMOTE_CONNECT}"' >> config/elasticsearch.yml
 
 RUN fix-permissions config
 
-ENV ES_JAVA_OPTS="-Xms400m -Xmx400m" \
+ENV ES_JAVA_OPTS="-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true" \
     NODE_MASTER=true \
     NODE_DATA=true \
     NODE_INGEST=true \

--- a/images/logstash/6.Dockerfile
+++ b/images/logstash/6.Dockerfile
@@ -39,6 +39,6 @@ ENV TMPDIR=/tmp \
 RUN fix-permissions /usr/share/logstash/data \
     && fix-permissions /usr/share/logstash/config
 
-ENV LS_JAVA_OPTS "-Xms400m -Xmx400m"
+ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash", "/usr/local/bin/docker-entrypoint"]

--- a/images/logstash/7.Dockerfile
+++ b/images/logstash/7.Dockerfile
@@ -37,6 +37,6 @@ ENV TMPDIR=/tmp \
 RUN fix-permissions /usr/share/logstash/data \
     && fix-permissions /usr/share/logstash/config
 
-ENV LS_JAVA_OPTS "-Xms400m -Xmx400m"
+ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash", "/usr/local/bin/docker-entrypoint"]

--- a/images/solr/7.7.Dockerfile
+++ b/images/solr/7.7.Dockerfile
@@ -37,6 +37,8 @@ RUN fix-permissions /var/solr \
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr
 
+ENV JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+
 COPY 10-solr-port.sh /lagoon/entrypoints/
 COPY 20-solr-datadir.sh /lagoon/entrypoints/
 

--- a/images/solr/7.7.Dockerfile
+++ b/images/solr/7.7.Dockerfile
@@ -37,7 +37,7 @@ RUN fix-permissions /var/solr \
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr
 
-ENV JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 
 COPY 10-solr-port.sh /lagoon/entrypoints/
 COPY 20-solr-datadir.sh /lagoon/entrypoints/

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -52,6 +52,8 @@ RUN fix-permissions /var/solr \
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr
 
+ENV JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+
 COPY 10-solr-port.sh /lagoon/entrypoints/
 COPY 20-solr-datadir.sh /lagoon/entrypoints/
 

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -52,7 +52,7 @@ RUN fix-permissions /var/solr \
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr
 
-ENV JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 
 COPY 10-solr-port.sh /lagoon/entrypoints/
 COPY 20-solr-datadir.sh /lagoon/entrypoints/

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -57,6 +57,8 @@ RUN chmod 775 /opt/docker-solr/scripts/solr-recreate
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr
 
+ENV JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+
 COPY 10-solr-port.sh /lagoon/entrypoints/
 # currently, there is no smart upgrade path from 7 to 8 - no autoremediation etc
 # and whilst sites may work, upgrading from 7 to 8, they won't work downgrading...

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -57,7 +57,7 @@ RUN chmod 775 /opt/docker-solr/scripts/solr-recreate
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr
 
-ENV JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 
 COPY 10-solr-port.sh /lagoon/entrypoints/
 # currently, there is no smart upgrade path from 7 to 8 - no autoremediation etc


### PR DESCRIPTION
This PR adds new `SOLR_OPTS` for our Solr images, new `ES_JAVA_OPTS` for our ElasticSearch images, and new `LS_JAVA_OPTS` for our Logstash images to patch the CVE-2021-44228 vulnerability announced earlier today. 

More information on this vulnerability can be found here: https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

Closes #357 