### PR TITLE
Removing unnecessary CVE-2021-44228 mitigations from ElasticSearch images

### DIFF
--- a/images/elasticsearch/6.Dockerfile
+++ b/images/elasticsearch/6.Dockerfile
@@ -46,7 +46,7 @@ discovery.zen.minimum_master_nodes: "${DISCOVERY_ZEN_MINIMUM_MASTER_NODES}"' >> 
 
 RUN fix-permissions config
 
-ENV ES_JAVA_OPTS="-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true" \
+ENV ES_JAVA_OPTS="-Xms400m -Xmx400m" \
     DISCOVERY_ZEN_MINIMUM_MASTER_NODES=1 \
     NODE_MASTER=true
 

--- a/images/elasticsearch/7.Dockerfile
+++ b/images/elasticsearch/7.Dockerfile
@@ -50,7 +50,7 @@ cluster.remote.connect: "${CLUSTER_REMOTE_CONNECT}"' >> config/elasticsearch.yml
 
 RUN fix-permissions config
 
-ENV ES_JAVA_OPTS="-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true" \
+ENV ES_JAVA_OPTS="-Xms400m -Xmx400m" \
     NODE_MASTER=true \
     NODE_DATA=true \
     NODE_INGEST=true \


### PR DESCRIPTION
After some internal research and an [update from Elastic about this CVE](https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476), this PR rolls back the mitigation put in place for our ElasticSearch images.