### PR TITLE
remove the JndiLookup class from the classpaths for CVE-2021-45046 and CVE-2021-44228

### DIFF
--- a/images/elasticsearch/6.Dockerfile
+++ b/images/elasticsearch/6.Dockerfile
@@ -35,6 +35,13 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
+
+# Mitigation for CVE-2021-45046 (already removed from first jar file)
+# RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/elasticsearch/bin/elasticsearch-sql-cli-6.8.21.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+
+
 RUN sed -i 's/discovery.zen.minimum_master_nodes: 1//' config/elasticsearch.yml
 
 RUN echo $'xpack.security.enabled: false\n\

--- a/images/elasticsearch/6.Dockerfile
+++ b/images/elasticsearch/6.Dockerfile
@@ -37,7 +37,7 @@ ENV TMPDIR=/tmp \
 
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
-# Mitigation for CVE-2021-45046 (already removed from first jar file)
+# Mitigation for CVE-2021-45046 and CVE-2021-44228 (already removed from first jar file)
 # RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 RUN zip -q -d /usr/share/elasticsearch/bin/elasticsearch-sql-cli-6.8.21.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/elasticsearch/7.Dockerfile
+++ b/images/elasticsearch/7.Dockerfile
@@ -35,6 +35,11 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
+
+# Mitigation for CVE-2021-45046
+RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+
 RUN echo $'\n\
 node.name: "${HOSTNAME}"\n\
 node.master: "${NODE_MASTER}"\n\

--- a/images/elasticsearch/7.Dockerfile
+++ b/images/elasticsearch/7.Dockerfile
@@ -38,7 +38,8 @@ ENV TMPDIR=/tmp \
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /usr/share/elasticsearch/bin/elasticsearch-sql-cli-7.8.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN echo $'\n\
 node.name: "${HOSTNAME}"\n\

--- a/images/elasticsearch/7.Dockerfile
+++ b/images/elasticsearch/7.Dockerfile
@@ -37,7 +37,7 @@ ENV TMPDIR=/tmp \
 
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
-# Mitigation for CVE-2021-45046
+# Mitigation for CVE-2021-45046 and CVE-2021-44228
 RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
     && zip -q -d /usr/share/elasticsearch/bin/elasticsearch-sql-cli-7.8.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/elasticsearch/7.Dockerfile
+++ b/images/elasticsearch/7.Dockerfile
@@ -38,7 +38,7 @@ ENV TMPDIR=/tmp \
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN echo $'\n\
 node.name: "${HOSTNAME}"\n\

--- a/images/logstash/6.Dockerfile
+++ b/images/logstash/6.Dockerfile
@@ -42,7 +42,7 @@ RUN fix-permissions /usr/share/logstash/data \
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.15.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 

--- a/images/logstash/6.Dockerfile
+++ b/images/logstash/6.Dockerfile
@@ -39,6 +39,11 @@ ENV TMPDIR=/tmp \
 RUN fix-permissions /usr/share/logstash/data \
     && fix-permissions /usr/share/logstash/config
 
+RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
+
+# Mitigation for CVE-2021-45046
+RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+
 ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash", "/usr/local/bin/docker-entrypoint"]

--- a/images/logstash/6.Dockerfile
+++ b/images/logstash/6.Dockerfile
@@ -41,7 +41,7 @@ RUN fix-permissions /usr/share/logstash/data \
 
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
-# Mitigation for CVE-2021-45046
+# Mitigation for CVE-2021-45046 and CVE-2021-44228
 RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.15.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
     && zip -q -d /usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-5.2.3-java/vendor/jar-dependencies/org/logstash/inputs/logstash-input-tcp/5.2.3/logstash-input-tcp-5.2.3.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/logstash/6.Dockerfile
+++ b/images/logstash/6.Dockerfile
@@ -42,7 +42,8 @@ RUN fix-permissions /usr/share/logstash/data \
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.15.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.15.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-5.2.3-java/vendor/jar-dependencies/org/logstash/inputs/logstash-input-tcp/5.2.3/logstash-input-tcp-5.2.3.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 

--- a/images/logstash/7.Dockerfile
+++ b/images/logstash/7.Dockerfile
@@ -39,7 +39,7 @@ RUN fix-permissions /usr/share/logstash/data \
 
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
-# Mitigation for CVE-2021-45046
+# Mitigation for CVE-2021-45046 and CVE-2021-44228
 RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.12.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
     && zip -q -d /usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-6.0.6-java/vendor/jar-dependencies/org/logstash/inputs/logstash-input-tcp/6.0.6/logstash-input-tcp-6.0.6.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/logstash/7.Dockerfile
+++ b/images/logstash/7.Dockerfile
@@ -40,7 +40,7 @@ RUN fix-permissions /usr/share/logstash/data \
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.12.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 

--- a/images/logstash/7.Dockerfile
+++ b/images/logstash/7.Dockerfile
@@ -40,7 +40,8 @@ RUN fix-permissions /usr/share/logstash/data \
 RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.12.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.12.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-6.0.6-java/vendor/jar-dependencies/org/logstash/inputs/logstash-input-tcp/6.0.6/logstash-input-tcp-6.0.6.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 

--- a/images/logstash/7.Dockerfile
+++ b/images/logstash/7.Dockerfile
@@ -37,6 +37,11 @@ ENV TMPDIR=/tmp \
 RUN fix-permissions /usr/share/logstash/data \
     && fix-permissions /usr/share/logstash/config
 
+RUN yum -y install zip && yum -y clean all  && rm -rf /var/cache
+
+# Mitigation for CVE-2021-45046
+RUN zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+
 ENV LS_JAVA_OPTS "-Xms400m -Xmx400m -Dlog4j2.formatMsgNoLookups=true"
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash", "/usr/local/bin/docker-entrypoint"]

--- a/images/solr/7.7.Dockerfile
+++ b/images/solr/7.7.Dockerfile
@@ -35,7 +35,7 @@ RUN fix-permissions /var/solr \
 
 RUN apk add --no-cache zip
 
-# Mitigation for CVE-2021-45046
+# Mitigation for CVE-2021-45046 and CVE-2021-44228
 RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
     && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/solr/7.7.Dockerfile
+++ b/images/solr/7.7.Dockerfile
@@ -33,6 +33,11 @@ RUN fix-permissions /var/solr \
     && fix-permissions /opt/solr/server/logs \
     && fix-permissions /opt/solr/server/solr
 
+RUN apk add --no-cache zip
+
+# Mitigation for CVE-2021-45046
+RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr

--- a/images/solr/7.7.Dockerfile
+++ b/images/solr/7.7.Dockerfile
@@ -36,8 +36,8 @@ RUN fix-permissions /var/solr \
 RUN apk add --no-cache zip
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
-    && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 # solr really doesn't like to be run as root, so we define the default user agin
 USER solr

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -29,7 +29,12 @@ USER root
 RUN apt-get -y update && apt-get -y install \
     busybox \
     curl \
+    zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Mitigation for CVE-2021-45046
+RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get -y update && apt-get -y install \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Mitigation for CVE-2021-45046
+# Mitigation for CVE-2021-45046 and CVE-2021-44228
 RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
     && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -33,8 +33,8 @@ RUN apt-get -y update && apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
-    && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /opt/solr/server/lib/ext/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /opt/solr/contrib/prometheus-exporter/lib/log4j-core-2.11.0.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -y update && apt-get -y install \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Mitigation for CVE-2021-45046
+# Mitigation for CVE-2021-45046 and CVE-2021-44228
 RUN zip -q -d /opt/solr-8.10.1/server/lib/ext/log4j-core-2.14.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
     && zip -q -d /opt/solr-8.10.1/contrib/prometheus-exporter/lib/log4j-core-2.14.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -31,7 +31,12 @@ USER root
 RUN apt-get -y update && apt-get -y install \
     busybox \
     curl \
+    zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Mitigation for CVE-2021-45046
+RUN zip -q -d /opt/solr-8.*/server/lib/ext/log4j-core-2.*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /opt/solr-8.*/contrib/prometheus-exporter/lib/log4j-core-2.*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get -y update && apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 
 # Mitigation for CVE-2021-45046
-RUN zip -q -d /opt/solr-8.*/server/lib/ext/log4j-core-2.*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
-    && zip -q -d /opt/solr-8.*/contrib/prometheus-exporter/lib/log4j-core-2.*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /opt/solr-8.10.1/server/lib/ext/log4j-core-2.14.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
+    && zip -q -d /opt/solr-8.10.1/contrib/prometheus-exporter/lib/log4j-core-2.14.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini


### PR DESCRIPTION
This PR actions the advice from the log4j team on how to best mitigate against CVE-2021-45046, namely removing the JndiLookup class from the classpath for all affected images

https://logging.apache.org/log4j/2.x/security.html

I've left the XX_OPTS in for the time being, but they can probably be removed