### PR TITLE
update PHP agents and apps

### DIFF
--- a/helpers/update-versions.yml
+++ b/helpers/update-versions.yml
@@ -8,18 +8,20 @@
   hosts: 127.0.0.1
   connection: local
   vars:
-    # Newrelic - https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
-    NEWRELIC_VERSION: '9.17.1.301'
+    # Newrelic - https://github.com/newrelic/newrelic-php-agent/releases
+    NEWRELIC_VERSION: '9.18.1.303'
+    # Blackfire Agent - https://github.com/blackfireio/docker/tags
+    BLACKFIRE_VERSION: '2.5.2'
     # Composer - https://getcomposer.org/download/
-    COMPOSER_VERSION: '1.10.22'
-    COMPOSER_HASH_SHA256: '6127ae192d3b56cd6758c7c72fe2ac6868ecc835dae1451a004aca10ab1e0700'
+    COMPOSER_VERSION: '1.10.24'
+    COMPOSER_HASH_SHA256: '542ce16add6fd5ecfb0049dd49a0214e69a966a602b42c215adb19438c13a890'
     # Drupal Console Launcher - https://github.com/hechoendrupal/drupal-console-launcher/releases
     DRUPAL_CONSOLE_LAUNCHER_VERSION: 1.9.7
     DRUPAL_CONSOLE_LAUNCHER_SHA: fe83050489c66a0578eb59d6744420be6fd4c5d1
     # Drush - https://github.com/drush-ops/drush/releases
-    DRUSH_VERSION: 8.4.8
+    DRUSH_VERSION: 8.4.10
     # Drush Launcher Version - https://github.com/drush-ops/drush-launcher/releases
-    DRUSH_LAUNCHER_VERSION: 0.9.1
+    DRUSH_LAUNCHER_VERSION: 0.9.3
   tasks:
   - name: Get a list of test*.conf in /home/user
     find:
@@ -35,6 +37,12 @@
         path: "{{ item.path }}"
         regexp: 'ENV NEWRELIC_VERSION=.*'
         replace: 'ENV NEWRELIC_VERSION={{ NEWRELIC_VERSION }}'
+    with_items: "{{ my_dockerfiles.files }}"
+  - name: update BLACKLFIRE_VERSION
+    replace:
+        path: "{{ item.path }}"
+        regexp: 'ENV BLACKFIRE_VERSION=.*'
+        replace: 'ENV BLACKFIRE_VERSION={{ BLACKFIRE_VERSION }}'
     with_items: "{{ my_dockerfiles.files }}"
   - name: update COMPOSER_VERSION
     replace:

--- a/images/php-cli-drupal/7.4.Dockerfile
+++ b/images/php-cli-drupal/7.4.Dockerfile
@@ -9,8 +9,8 @@ ENV LAGOON=cli-drupal
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=fe83050489c66a0578eb59d6744420be6fd4c5d1 \
-    DRUSH_VERSION=8.4.8 \
-    DRUSH_LAUNCHER_VERSION=0.9.1 \
+    DRUSH_VERSION=8.4.10 \
+    DRUSH_LAUNCHER_VERSION=0.9.3 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 
 RUN curl -L -o /usr/local/bin/drupal "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" \

--- a/images/php-cli-drupal/8.0.Dockerfile
+++ b/images/php-cli-drupal/8.0.Dockerfile
@@ -9,8 +9,8 @@ ENV LAGOON=cli-drupal
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=fe83050489c66a0578eb59d6744420be6fd4c5d1 \
-    DRUSH_VERSION=8.4.8 \
-    DRUSH_LAUNCHER_VERSION=0.9.1 \
+    DRUSH_VERSION=8.4.10 \
+    DRUSH_LAUNCHER_VERSION=0.9.3 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 
 RUN curl -L -o /usr/local/bin/drupal "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" \

--- a/images/php-cli-drupal/8.1.Dockerfile
+++ b/images/php-cli-drupal/8.1.Dockerfile
@@ -9,8 +9,8 @@ ENV LAGOON=cli-drupal
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=fe83050489c66a0578eb59d6744420be6fd4c5d1 \
-    DRUSH_VERSION=8.4.8 \
-    DRUSH_LAUNCHER_VERSION=0.9.1 \
+    DRUSH_VERSION=8.4.10 \
+    DRUSH_LAUNCHER_VERSION=0.9.3 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 
 RUN curl -L -o /usr/local/bin/drupal "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" \

--- a/images/php-cli/7.4.Dockerfile
+++ b/images/php-cli/7.4.Dockerfile
@@ -8,8 +8,8 @@ ENV LAGOON=cli
 
 # Defining Versions - Composer
 # @see https://getcomposer.org/download/
-ENV COMPOSER_VERSION=1.10.22 \
-  COMPOSER_HASH_SHA256=6127ae192d3b56cd6758c7c72fe2ac6868ecc835dae1451a004aca10ab1e0700
+ENV COMPOSER_VERSION=1.10.24 \
+  COMPOSER_HASH_SHA256=542ce16add6fd5ecfb0049dd49a0214e69a966a602b42c215adb19438c13a890
 
 RUN apk add --no-cache git \
         unzip \

--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -86,7 +86,7 @@ RUN docker-php-ext-configure gd --with-webp --with-jpeg \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.17.1.301
+ENV NEWRELIC_VERSION=9.18.1.303
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
@@ -112,7 +112,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.4.2
+ENV BLACKFIRE_VERSION=2.5.2
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -86,7 +86,7 @@ RUN docker-php-ext-configure gd --with-webp --with-jpeg \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.17.1.301
+ENV NEWRELIC_VERSION=9.18.1.303
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
@@ -112,7 +112,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.4.2
+ENV BLACKFIRE_VERSION=2.5.2
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -86,7 +86,7 @@ RUN docker-php-ext-configure gd --with-webp --with-jpeg \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-# ENV NEWRELIC_VERSION=9.17.1.301
+# ENV NEWRELIC_VERSION=9.18.1.303
 # RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
 #     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
 #     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
@@ -112,7 +112,7 @@ RUN docker-php-ext-configure gd --with-webp --with-jpeg \
 #     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
 #     && fix-permissions /usr/local/etc/php/conf.d/
 
-# ENV BLACKFIRE_VERSION=2.4.2
+# ENV BLACKFIRE_VERSION=2.5.2
 # RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
 #     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
 #     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \


### PR DESCRIPTION
This PR updates the following packages:

* NewRelic PHP Agent to 9.18.1.303
* Blackfire Agent to 2.5.2
* Composer 1.x to 1.10.24
* Drush 8.x to 8.4.10
* Drush Launcher to 0.9.3

closes #375