### PR TITLE
Updating drush config to consume the MARIADB_MAX_ALLOWED_PACKET variable

### DIFF
--- a/images/php-cli-drupal/7.4.Dockerfile
+++ b/images/php-cli-drupal/7.4.Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lago
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ENV LAGOON=cli-drupal
+ENV MARIADB_MAX_ALLOWED_PACKET=64M
 
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \

--- a/images/php-cli-drupal/8.0.Dockerfile
+++ b/images/php-cli-drupal/8.0.Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lago
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ENV LAGOON=cli-drupal
+ENV MARIADB_MAX_ALLOWED_PACKET=64M
 
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \

--- a/images/php-cli-drupal/8.1.Dockerfile
+++ b/images/php-cli-drupal/8.1.Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lago
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ENV LAGOON=cli-drupal
+ENV MARIADB_MAX_ALLOWED_PACKET=64M
 
 # Defining Versions - https://github.com/hechoendrupal/drupal-console-launcher/releases
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \

--- a/images/php-cli-drupal/drush.yml
+++ b/images/php-cli-drupal/drush.yml
@@ -4,3 +4,8 @@
 options:
   root: '/app/${env.WEBROOT}'
   uri: '${env.LAGOON_ROUTE}'
+command:
+  sql:
+    dump:
+      options:
+        extra-dump: --no-tablespaces --max_allowed_packet=${env.MARIADB_MAX_ALLOWED_PACKET}


### PR DESCRIPTION
We recently discovered that drush doesn't consume the `MARIADB_MAX_ALLOWED_PACKET` value, which can cause issues for suers with larger than usual tables. This PR adds that value to the `drush.yml` file, and adds a sane default of `64M` which can be overwritten if needed.