### PR TITLE
update existing images to alpine 3.15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ node ('lagoon-images') {
             sh script: "git submodule add -b php81 https://github.com/lagoon-examples/drupal9-base drupal9-base-php81"
             sh script: "git submodule sync && git submodule update --init"
             sh script: "mkdir -p ./all-images && cp ../helpers/docker-compose.yml ./all-images/ && cp ../helpers/TESTING_dockercompose.md ./all-images/"
+            sh script: "sed -i '/image:/ s/uselagoon/${CI_BUILD_TAG}/' ./all-images/docker-compose.yml"
             sh script: "yarn install"
             sh script: "yarn generate-tests"
             sh script: "docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network"

--- a/Makefile
+++ b/Makefile
@@ -179,21 +179,29 @@ build/rabbitmq-cluster: build/rabbitmq images/rabbitmq-cluster/Dockerfile
 
 versioned-images := 		php-7.4-fpm \
 							php-8.0-fpm \
+							php-8.1-fpm \
 							php-7.4-cli \
 							php-8.0-cli \
+							php-8.1-cli \
 							php-7.4-cli-drupal \
 							php-8.0-cli-drupal \
+							php-8.1-cli-drupal \
 							python-3.7 \
 							python-3.8 \
 							python-3.9 \
+							python-3.10 \
 							node-12 \
-							node-14 \
-							node-16 \
 							node-12-builder \
+							node-14 \
 							node-14-builder \
+							node-16 \
 							node-16-builder \
 							solr-7.7 \
 							solr-7.7-drupal \
+							solr-7 \
+							solr-7-drupal \
+							solr-8 \
+							solr-8-drupal \
 							elasticsearch-6 \
 							elasticsearch-7 \
 							kibana-6 \
@@ -201,19 +209,18 @@ versioned-images := 		php-7.4-fpm \
 							logstash-6 \
 							logstash-7 \
 							postgres-12 \
+							postgres-13 \
+							postgres-14 \
 							redis-6 \
 							redis-6-persistent \
-							solr-7 \
-							solr-7-drupal \
 							mariadb-10.5 \
 							mariadb-10.5-drupal \
+							mariadb-10.6 \
+							mariadb-10.6-drupal \
 							varnish-6 \
 							varnish-6-drupal \
 							varnish-6-persistent \
-							varnish-6-persistent-drupal \
-							php-8.1-fpm \
-							php-8.1-cli \
-							php-8.1-cli-drupal
+							varnish-6-persistent-drupal
 
 # default-versioned-images are images that formerly had no versioning, and are made backwards-compatible.
 # the below versions are the ones that map to the unversioned namespace
@@ -234,8 +241,7 @@ default-versioned-images := 	mariadb-10.4 \
 ####### Experimental Images
 #######
 
-experimental-images := 		solr-8 \
-							solr-8-drupal
+experimental-images := 		
 
 build-versioned-images = $(foreach image,$(versioned-images) $(default-versioned-images) $(experimental-images),build/$(image))
 
@@ -270,7 +276,7 @@ build/php-8.1-cli: build/php-8.1-fpm
 build/php-7.4-cli-drupal: build/php-7.4-cli
 build/php-8.0-cli-drupal: build/php-8.0-cli
 build/php-8.1-cli-drupal: build/php-8.1-cli
-build/python-3.7 build/python-3.8 build/python-3.9: build/commons
+build/python-3.7 build/python-3.8 build/python-3.9 build/python-3.10: build/commons
 build/node-12 build/node-14 build/node-16: build/commons
 build/node-12-builder: build/node-12
 build/node-14-builder: build/node-14
@@ -278,8 +284,11 @@ build/node-16-builder: build/node-16
 build/solr-7.7: build/commons
 build/solr-7.7-drupal: build/solr-7.7
 build/elasticsearch-6 build/elasticsearch-7 build/kibana-6 build/kibana-7 build/logstash-6 build/logstash-7: build/commons
-build/postgres-11 build/postgres-12: build/commons
+build/postgres-11 build/postgres-12 build/postgres-13 build/postgres-14: build/commons
 build/postgres-11-ckan build/postgres-11-drupal: build/postgres-11
+build/postgres-14-drupal: build/postgres-12
+build/postgres-13-drupal: build/postgres-13
+build/postgres-14-drupal: build/postgres-14
 build/redis-5 build/redis-6: build/commons
 build/redis-5-persistent: build/redis-5
 build/redis-6-persistent: build/redis-6
@@ -291,9 +300,10 @@ build/varnish-6-persistent-drupal: build/varnish-6-drupal
 build/solr-7 build/solr-8: build/commons
 build/solr-7-drupal: build/solr-7
 build/solr-8-drupal: build/solr-8
-build/mariadb-10.4 build/mariadb-10.5: build/commons
+build/mariadb-10.4 build/mariadb-10.5 build/mariadb-10.6: build/commons
 build/mariadb-10.4-drupal: build/mariadb-10.4
 build/mariadb-10.5-drupal: build/mariadb-10.5
+build/mariadb-10.6-drupal: build/mariadb-10.6
 
 #######
 ####### Building Images

--- a/helpers/TESTING_dockercompose.md
+++ b/helpers/TESTING_dockercompose.md
@@ -20,8 +20,11 @@ docker-compose build && docker-compose up -d
 # Ensure database pods are ready to connect
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10.4:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10.5:3306 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10.6:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-11:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-12:5432 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-13:5432 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-14:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mongo:27017 -timeout 1m
 ```
 
@@ -34,19 +37,25 @@ Run the following commands to validate things are rolling as they should.
 # Should have all the services we expect
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.4_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.5_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.6_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mongo_1
 docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_node-12_1
 docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_node-14_1
 docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_node-16_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-11_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-12_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-13_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-14_1
 docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_python-3.7_1
 docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_python-3.8_1
 docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_python-3.9_1
+docker ps -a --filter label=com.docker.compose.project=all-images | grep Exited | grep all-images_python-3.10_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_rabbitmq_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_redis-5_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_redis-6_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_solr-7_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_solr-7.7_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_solr-8_1
 
 # commons Should be running Alpine Linux
 docker-compose exec -T commons sh -c "cat /etc/os-release" | grep "Alpine Linux"
@@ -85,7 +94,16 @@ docker-compose exec -T commons sh -c "curl solr-7:8983/solr/admin/cores?action=S
 docker-compose exec -T commons sh -c "curl solr-7:8983/solr/admin/cores?action=RELOAD\&core=mycore"
 
 # solr-7 Check Solr has 7.7 solrconfig in "mycore" core
-docker-compose exec -T solr-7 sh -c "cat /opt/solr/server/solr/mycores/mycore/conf/solrconfig.xml" | grep 7.7
+docker-compose exec -T solr-7 sh -c "cat /opt/solr/server/solr/mycores/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 7.7
+
+# solr-8 Should have a "mycore" Solr core
+docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=STATUS\&core=mycore"
+
+# solr-8 Should be able to reload "mycore" Solr core
+docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=RELOAD\&core=mycore"
+
+# solr-8 Check Solr has 8 solrconfig in "mycore" core
+docker-compose exec -T solr-8 sh -c "cat /var/solr/data/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 8.
 
 # solr-7.7 Should have a "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-7.7:8983/solr/admin/cores?action=STATUS\&core=mycore"
@@ -94,7 +112,7 @@ docker-compose exec -T commons sh -c "curl solr-7.7:8983/solr/admin/cores?action
 docker-compose exec -T commons sh -c "curl solr-7.7:8983/solr/admin/cores?action=RELOAD\&core=mycore"
 
 # solr-7.7 Check Solr has 7.7 solrconfig in "mycore" core
-docker-compose exec -T solr-7.7 sh -c "cat /opt/solr/server/solr/mycores/mycore/conf/solrconfig.xml" | grep 7.7
+docker-compose exec -T solr-7.7 sh -c "cat /opt/solr/server/solr/mycores/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 7.7
 
 # mariadb-10.4 should be version 10.4 client
 docker-compose exec -T mariadb-10.4 sh -c "mysql -V" | grep "10.4"
@@ -114,6 +132,15 @@ docker-compose exec -T mariadb-10.5 sh -c "mysql -e \'SHOW variables;\'" | grep 
 # mariadb-10.5 check default credentials
 docker-compose exec -T mariadb-10.5 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
+# mariadb-10.6 should be version 10.6 client
+docker-compose exec -T mariadb-10.6 sh -c "mysql -V" | grep "10.6"
+
+# mariadb-10.6 should be version 10.6 server
+docker-compose exec -T mariadb-10.6 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.6"
+
+# mariadb-10.6 check default credentials
+docker-compose exec -T mariadb-10.6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
+
 # mongo should be version 3.6 client
 docker-compose exec -T mongo sh -c "mongo --version" | grep "shell version" | grep "v3.6"
 
@@ -132,7 +159,7 @@ docker-compose exec -T postgres-11 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 # postgres-11 should have lagoon database
 docker-compose exec -T postgres-11 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
 
-# postgres-12 should be version 11 client
+# postgres-12 should be version 12 client
 docker-compose exec -T postgres-12 bash -c "psql --version" | grep "psql" | grep "12."
 
 # postgres-12 should be version 12 server
@@ -140,6 +167,24 @@ docker-compose exec -T postgres-12 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 
 # postgres-12 should have lagoon database
 docker-compose exec -T postgres-12 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
+
+# postgres-13 should be version 13 client
+docker-compose exec -T postgres-13 bash -c "psql --version" | grep "psql" | grep "13."
+
+# postgres-13 should be version 13 server
+docker-compose exec -T postgres-13 bash -c "psql -U lagoon -d lagoon -c \'SELECT version();\'" | grep "PostgreSQL" | grep "13."
+
+# postgres-13 should have lagoon database
+docker-compose exec -T postgres-13 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
+
+# postgres-14 should be version 14 client
+docker-compose exec -T postgres-14 bash -c "psql --version" | grep "psql" | grep "14."
+
+# postgres-14 should be version 14 server
+docker-compose exec -T postgres-14 bash -c "psql -U lagoon -d lagoon -c \'SELECT version();\'" | grep "PostgreSQL" | grep "14."
+
+# postgres-14 should have lagoon database
+docker-compose exec -T postgres-14 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
 ```
 
 Destroy tests

--- a/helpers/docker-compose.yml
+++ b/helpers/docker-compose.yml
@@ -26,6 +26,14 @@ services:
       - "3306" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
     << : *default-user # uses the defined user from top
 
+  mariadb-10.6:
+    image: uselagoon/mariadb-10.6:latest
+    labels:
+      lando.type: mariadb
+    ports:
+      - "3306" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
+    << : *default-user # uses the defined user from top
+
   mongo:
     image: uselagoon/mongo:latest
     ports:
@@ -73,6 +81,24 @@ services:
       - "5432" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
     << : *default-user # uses the defined user from top
 
+
+  postgres-13:
+    image: uselagoon/postgres-13:latest
+    labels:
+      lando.type: postgres
+    ports:
+      - "5432" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
+    << : *default-user # uses the defined user from top
+
+
+  postgres-14:
+    image: uselagoon/postgres-14:latest
+    labels:
+      lando.type: postgres
+    ports:
+      - "5432" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
+    << : *default-user # uses the defined user from top
+
   python-3.7:
     image: uselagoon/python-3.7:latest
     << : *default-user # uses the defined user from top
@@ -85,6 +111,9 @@ services:
     image: uselagoon/python-3.9:latest
     << : *default-user # uses the defined user from top
 
+  python-3.10:
+    image: uselagoon/python-3.10:latest
+    << : *default-user # uses the defined user from top
   rabbitmq:
     image: uselagoon/rabbitmq:latest
     << : *default-user # uses the defined user from top
@@ -122,6 +151,12 @@ services:
     ports:
       - "8983" # exposes the port 8983 with a random local port, find it with `docker-compose port solr 8983`
 
+  solr-8:
+    image: uselagoon/solr-8:latest
+    labels:
+      lando.type: solr
+    ports:
+      - "8983" # exposes the port 8983 with a random local port, find it with `docker-compose port solr 8983`
 networks:
   amazeeio-network:
     external: true

--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -1,7 +1,7 @@
 FROM webdevops/go-crond:21.5.0-alpine AS go-crond
 FROM amazeeio/envplate:v1.0.0-rc.3 AS envplate
 
-FROM alpine:3.14.3
+FROM alpine:3.15.0
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/mariadb-drupal/10.6.Dockerfile
+++ b/images/mariadb-drupal/10.6.Dockerfile
@@ -1,0 +1,9 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/mariadb-10.6
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV MARIADB_DATABASE=drupal \
+    MARIADB_USER=drupal \
+    MARIADB_PASSWORD=drupal

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -1,0 +1,78 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM alpine:3.15.0
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+ENV BACKUPS_DIR="/var/lib/mysql/backup"
+
+ENV MARIADB_DATABASE=lagoon \
+    MARIADB_USER=lagoon \
+    MARIADB_PASSWORD=lagoon \
+    MARIADB_ROOT_PASSWORD=Lag00n
+
+RUN \
+    apk add --no-cache --virtual .common-run-deps \
+    bash \
+    curl \
+    mariadb=~10.6 \
+    mariadb-client=~10.6 \
+    mariadb-common=~10.6 \
+    mariadb-server-utils=~10.6 \
+    net-tools \
+    pwgen \
+    tzdata \
+    wget \
+    gettext; \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
+    rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
+    curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+
+COPY entrypoints/ /lagoon/entrypoints/
+COPY mysql-backup.sh /lagoon/
+COPY my.cnf /etc/mysql/my.cnf
+
+RUN for i in /var/run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d/ "${BACKUPS_DIR}" /home; \
+    do mkdir -p $i; chown mysql $i; /bin/fix-permissions $i; \
+    done
+
+COPY root/usr/share/container-scripts/mysql/readiness-probe.sh /usr/share/container-scripts/mysql/readiness-probe.sh
+RUN /bin/fix-permissions /usr/share/container-scripts/mysql/ \
+    && /bin/fix-permissions /etc/mysql
+
+RUN touch /var/log/mariadb-slow.log && /bin/fix-permissions /var/log/mariadb-slow.log \
+    && touch /var/log/mariadb-queries.log && /bin/fix-permissions /var/log/mariadb-queries.log
+
+# We cannot start mysql as root, we add the user mysql to the group root and
+# change the user of the Docker Image to this user.
+RUN addgroup mysql root
+USER mysql
+ENV USER_NAME mysql
+
+WORKDIR /var/lib/mysql
+VOLUME /var/lib/mysql
+EXPOSE 3306
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+CMD ["mysqld"]

--- a/images/node/12.Dockerfile
+++ b/images/node/12.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:12.22-alpine3.14
+FROM node:12.22-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/14.Dockerfile
+++ b/images/node/14.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:14.19-alpine3.14
+FROM node:14.19-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/16.Dockerfile
+++ b/images/node/16.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:16.14-alpine3.14
+FROM node:16.14-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:7.4.27-fpm-alpine3.14
+FROM php:7.4.27-fpm-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.0.15-fpm-alpine3.14
+FROM php:8.0.15-fpm-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.1.2-fpm-alpine3.14
+FROM php:8.1.2-fpm-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres-drupal/12.Dockerfile
+++ b/images/postgres-drupal/12.Dockerfile
@@ -1,0 +1,13 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/postgres-12
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+# change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
+RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \
+    && sed -i "s/#log_min_messages = warning/log_min_messages = log/" /usr/local/share/postgresql/postgresql.conf.sample
+
+ENV POSTGRES_PASSWORD=drupal \
+    POSTGRES_USER=drupal \
+    POSTGRES_DB=drupal

--- a/images/postgres-drupal/13.Dockerfile
+++ b/images/postgres-drupal/13.Dockerfile
@@ -1,0 +1,13 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/postgres-13
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+# change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
+RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \
+    && sed -i "s/#log_min_messages = warning/log_min_messages = log/" /usr/local/share/postgresql/postgresql.conf.sample
+
+ENV POSTGRES_PASSWORD=drupal \
+    POSTGRES_USER=drupal \
+    POSTGRES_DB=drupal

--- a/images/postgres-drupal/14.Dockerfile
+++ b/images/postgres-drupal/14.Dockerfile
@@ -1,0 +1,13 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/postgres-14
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+# change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
+RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \
+    && sed -i "s/#log_min_messages = warning/log_min_messages = log/" /usr/local/share/postgresql/postgresql.conf.sample
+
+ENV POSTGRES_PASSWORD=drupal \
+    POSTGRES_USER=drupal \
+    POSTGRES_DB=drupal

--- a/images/postgres/11.Dockerfile
+++ b/images/postgres/11.Dockerfile
@@ -1,7 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# alpine 3.12 from https://github.com/docker-library/postgres/blob/1dcdff4b410936b5b11d1e25c6b60a002b2fc9b9/11/alpine/Dockerfile
-FROM postgres:11.14-alpine
+FROM postgres:11.14-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres/12.Dockerfile
+++ b/images/postgres/12.Dockerfile
@@ -1,7 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# alpine 3.12 from https://github.com/docker-library/postgres/blob/6f58eab268f60c9dfcfe8a7e3fba7499f239236b/12/alpine/Dockerfile
-FROM postgres:12.9-alpine
+FROM postgres:12.9-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres/13.Dockerfile
+++ b/images/postgres/13.Dockerfile
@@ -1,0 +1,42 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM postgres:13.5-alpine3.15
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV LAGOON=postgres
+
+COPY postgres-backup.sh /lagoon/
+
+RUN echo -e "local all all md5\nhost  all  all 0.0.0.0/0 md5" >> /usr/local/share/postgresql/pg_hba.conf
+
+ENV PGUSER=postgres \
+    POSTGRES_PASSWORD=lagoon \
+    POSTGRES_USER=lagoon \
+    POSTGRES_DB=lagoon \
+    PGDATA=/var/lib/postgresql/data/pgdata
+
+# Postgresql entrypoint file needs bash, so start the entrypoints with bash
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+CMD ["/usr/local/bin/docker-entrypoint.sh", "postgres"]

--- a/images/postgres/14.Dockerfile
+++ b/images/postgres/14.Dockerfile
@@ -1,0 +1,42 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM postgres:14.1-alpine3.15
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV LAGOON=postgres
+
+COPY postgres-backup.sh /lagoon/
+
+RUN echo -e "local all all md5\nhost  all  all 0.0.0.0/0 md5" >> /usr/local/share/postgresql/pg_hba.conf
+
+ENV PGUSER=postgres \
+    POSTGRES_PASSWORD=lagoon \
+    POSTGRES_USER=lagoon \
+    POSTGRES_DB=lagoon \
+    PGDATA=/var/lib/postgresql/data/pgdata
+
+# Postgresql entrypoint file needs bash, so start the entrypoints with bash
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+CMD ["/usr/local/bin/docker-entrypoint.sh", "postgres"]

--- a/images/python/3.10.Dockerfile
+++ b/images/python/3.10.Dockerfile
@@ -1,0 +1,39 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+
+FROM python:3.10.2-alpine3.15
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=python
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+RUN apk add --no-cache --virtual .build-deps \
+      build-base \
+    && pip install --upgrade pip \
+    && pip install virtualenv \
+    && apk del .build-deps
+
+# Make sure shells are not running forever
+COPY 80-shell-timeout.sh /lagoon/entrypoints/
+RUN echo "source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["python"]

--- a/images/python/3.7.Dockerfile
+++ b/images/python/3.7.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.7.12-alpine3.14
+FROM python:3.7.12-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.8.12-alpine3.14
+FROM python:3.8.12-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.9.Dockerfile
+++ b/images/python/3.9.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.9.10-alpine3.14
+FROM python:3.9.10-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/redis/5.Dockerfile
+++ b/images/redis/5.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM redis:5.0.14-alpine3.14
+FROM redis:5.0.14-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/redis/6.Dockerfile
+++ b/images/redis/6.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM redis:6.2.6-alpine3.14
+FROM redis:6.2.6-alpine3.15
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
Quite a bit here - firstly, all images are updated to alpine 3.15 (https://alpinelinux.org/posts/Alpine-3.15.0-released.html)

Secondly, we've added the following images:
* Python 3.10
* Postgres 13 and Postgres 14 (and -drupal variants)
* MariaDB 10.6 (and -drupal variant)
* Solr 8 has been moved from an "Experimental" to a published image

Thirdly, we've added additional testing for the above images