### PR TITLE
Add support for configurable wait_timeout

### DIFF
--- a/images/mariadb/my.cnf
+++ b/images/mariadb/my.cnf
@@ -38,5 +38,6 @@ transaction-isolation = READ-COMMITTED
 skip-name-resolve
 optimizer_search_depth = 0
 innodb_flush_log_at_trx_commit = 0
+wait_timeout = ${MARIADB_WAIT_TIMEOUT:-28800}
 
 !includedir /etc/mysql/conf.d


### PR DESCRIPTION
This allows a configurable wait_timeout value which retains the default `28800` value if not defined