### PR TITLE
Invoke chmod once per directory to fix permissions

### DIFF
--- a/images/commons/fix-permissions
+++ b/images/commons/fix-permissions
@@ -2,5 +2,4 @@
 # Fix permissions on the given directory to allow group read/write of
 # regular files and execute of directories.
 find -L "$1" -exec chgrp 0 {} +
-find -L "$1" -exec chmod g+rw {} +
-find -L "$1" -type d -exec chmod g+x {} +
+find -L "$1" -exec chmod g+rwX {} +


### PR DESCRIPTION
## Change proposed

I noticed that `fix-permissions` was traversing the file system twice to set the file mode bits on directories. We can set all file mode bits for both directories and files at the same time. 

We could select file mode letter capital X - see `chmod` man page 

> (X) : execute (or search for directories) only if the file is a directory or already has execute permission for some user

This doesn't change build speed by much but I thought I'd share it anyway. It simplifies the permissions change using a common, long supported method.