### PR TITLE
update helper tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,9 +326,9 @@ build-list:
 scan-images:
 	rm -f ./scans/*.txt
 	@for tag in $(foreach image,$(base-images) $(base-images-with-versions),$(image)); do \
-			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/root/.cache/ aquasec/trivy --timeout 5m0s $(CI_BUILD_TAG)/$$tag > ./scans/$$tag.trivy.txt ; \
+			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/root/.cache/ aquasec/trivy image --timeout 5m0s $(CI_BUILD_TAG)/$$tag > ./scans/$$tag.trivy.txt ; \
 			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock anchore/syft $(CI_BUILD_TAG)/$$tag > ./scans/$$tag.syft.txt ; \
-			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/var/lib/grype/db anchore/grype $(CI_BUILD_TAG)/$$tag > ./scans/$$tag.grype.txt ; \
+			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/var/lib/grype/db anchore/grype --add-cpes-if-none $(CI_BUILD_TAG)/$$tag > ./scans/$$tag.grype.txt ; \
 			echo $$tag ; \
 	done
 

--- a/helpers/update-versions.yml
+++ b/helpers/update-versions.yml
@@ -9,19 +9,19 @@
   connection: local
   vars:
     # Newrelic - https://github.com/newrelic/newrelic-php-agent/releases
-    NEWRELIC_VERSION: '9.18.1.303'
+    NEWRELIC_VERSION: '9.20.0.310'
     # Blackfire Agent - https://github.com/blackfireio/docker/tags
-    BLACKFIRE_VERSION: '2.5.2'
+    BLACKFIRE_VERSION: '2.7.0'
     # Composer - https://getcomposer.org/download/
-    COMPOSER_VERSION: '1.10.24'
-    COMPOSER_HASH_SHA256: '542ce16add6fd5ecfb0049dd49a0214e69a966a602b42c215adb19438c13a890'
+    COMPOSER_VERSION: '1.10.25'
+    COMPOSER_HASH_SHA256: '6b089bd8b78b00c3c15d7b13353fbcbdf16a3f5248203c9a3e76f13948f2de92'
     # Drupal Console Launcher - https://github.com/hechoendrupal/drupal-console-launcher/releases
     DRUPAL_CONSOLE_LAUNCHER_VERSION: 1.9.7
     DRUPAL_CONSOLE_LAUNCHER_SHA: fe83050489c66a0578eb59d6744420be6fd4c5d1
     # Drush - https://github.com/drush-ops/drush/releases
     DRUSH_VERSION: 8.4.10
     # Drush Launcher Version - https://github.com/drush-ops/drush-launcher/releases
-    DRUSH_LAUNCHER_VERSION: 0.9.3
+    DRUSH_LAUNCHER_VERSION: 0.10.1
   tasks:
   - name: Get a list of test*.conf in /home/user
     find:

--- a/images/php-cli-drupal/7.4.Dockerfile
+++ b/images/php-cli-drupal/7.4.Dockerfile
@@ -10,7 +10,7 @@ ENV LAGOON=cli-drupal
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=fe83050489c66a0578eb59d6744420be6fd4c5d1 \
     DRUSH_VERSION=8.4.10 \
-    DRUSH_LAUNCHER_VERSION=0.9.3 \
+    DRUSH_LAUNCHER_VERSION=0.10.1 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 
 RUN curl -L -o /usr/local/bin/drupal "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" \

--- a/images/php-cli-drupal/8.0.Dockerfile
+++ b/images/php-cli-drupal/8.0.Dockerfile
@@ -10,7 +10,7 @@ ENV LAGOON=cli-drupal
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=fe83050489c66a0578eb59d6744420be6fd4c5d1 \
     DRUSH_VERSION=8.4.10 \
-    DRUSH_LAUNCHER_VERSION=0.9.3 \
+    DRUSH_LAUNCHER_VERSION=0.10.1 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 
 RUN curl -L -o /usr/local/bin/drupal "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" \

--- a/images/php-cli-drupal/8.1.Dockerfile
+++ b/images/php-cli-drupal/8.1.Dockerfile
@@ -10,7 +10,7 @@ ENV LAGOON=cli-drupal
 ENV DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
     DRUPAL_CONSOLE_LAUNCHER_SHA=fe83050489c66a0578eb59d6744420be6fd4c5d1 \
     DRUSH_VERSION=8.4.10 \
-    DRUSH_LAUNCHER_VERSION=0.9.3 \
+    DRUSH_LAUNCHER_VERSION=0.10.1 \
     DRUSH_LAUNCHER_FALLBACK=/opt/drush8/vendor/bin/drush
 
 RUN curl -L -o /usr/local/bin/drupal "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" \

--- a/images/php-cli/7.4.Dockerfile
+++ b/images/php-cli/7.4.Dockerfile
@@ -8,8 +8,8 @@ ENV LAGOON=cli
 
 # Defining Versions - Composer
 # @see https://getcomposer.org/download/
-ENV COMPOSER_VERSION=1.10.24 \
-  COMPOSER_HASH_SHA256=542ce16add6fd5ecfb0049dd49a0214e69a966a602b42c215adb19438c13a890
+ENV COMPOSER_VERSION=1.10.25 \
+  COMPOSER_HASH_SHA256=6b089bd8b78b00c3c15d7b13353fbcbdf16a3f5248203c9a3e76f13948f2de92
 
 RUN apk add --no-cache git \
         unzip \

--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -99,7 +99,7 @@ RUN apk add --no-cache --virtual .devdeps \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.18.1.303
+ENV NEWRELIC_VERSION=9.20.0.310
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
@@ -125,7 +125,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.5.2
+ENV BLACKFIRE_VERSION=2.7.0
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -99,7 +99,7 @@ RUN apk add --no-cache --virtual .devdeps \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.18.1.303
+ENV NEWRELIC_VERSION=9.20.0.310
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
@@ -125,7 +125,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.5.2
+ENV BLACKFIRE_VERSION=2.7.0
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -95,45 +95,44 @@ RUN apk add --no-cache --virtual .devdeps \
         imagemagick \
         imagemagick-libs
 
-
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-# ENV NEWRELIC_VERSION=9.18.1.303
-# RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
-#     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
-#     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
-#     && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
-#     && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/;newrelic.browser_monitoring.auto_instrument = .*/newrelic.browser_monitoring.auto_instrument = \${NEWRELIC_BROWSER_MONITORING_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/newrelic.license = .*/newrelic.license = \"\${NEWRELIC_LICENSE:-}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/;newrelic.loglevel = .*/newrelic.loglevel = \"\${NEWRELIC_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/;newrelic.daemon.loglevel = .*/newrelic.daemon.loglevel = \"\${NEWRELIC_DAEMON_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/newrelic.logfile = .*/newrelic.logfile = \"\/dev\/stderr\"/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && sed -i -e "s/newrelic.daemon.logfile = .*/newrelic.daemon.logfile = \"\/dev\/stderr\"/" /usr/local/etc/php/conf.d/newrelic.ini \
-#     && mv /usr/local/etc/php/conf.d/newrelic.ini /usr/local/etc/php/conf.d/newrelic.disable \
-#     && cd / && rm -rf /tmp/newrelic \
-#     && fix-permissions /usr/local/etc/
+ENV NEWRELIC_VERSION=9.20.0.310
+RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
+    && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
+    && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
+    && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
+    && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/;newrelic.browser_monitoring.auto_instrument = .*/newrelic.browser_monitoring.auto_instrument = \${NEWRELIC_BROWSER_MONITORING_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/newrelic.license = .*/newrelic.license = \"\${NEWRELIC_LICENSE:-}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/;newrelic.loglevel = .*/newrelic.loglevel = \"\${NEWRELIC_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/;newrelic.daemon.loglevel = .*/newrelic.daemon.loglevel = \"\${NEWRELIC_DAEMON_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/newrelic.logfile = .*/newrelic.logfile = \"\/dev\/stderr\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && sed -i -e "s/newrelic.daemon.logfile = .*/newrelic.daemon.logfile = \"\/dev\/stderr\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+    && mv /usr/local/etc/php/conf.d/newrelic.ini /usr/local/etc/php/conf.d/newrelic.disable \
+    && cd / && rm -rf /tmp/newrelic \
+    && fix-permissions /usr/local/etc/
 
 # Add blackfire probe and agent.
-# RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
-#     && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
-#     && mkdir -p /blackfire \
-#     && curl -A "Docker" -o /blackfire/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/$architecture/$version \
-#     && tar zxpf /blackfire/blackfire-probe.tar.gz -C /blackfire \
-#     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
-#     && fix-permissions /usr/local/etc/php/conf.d/
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && mkdir -p /blackfire \
+    && curl -A "Docker" -o /blackfire/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/$architecture/$version \
+    && tar zxpf /blackfire/blackfire-probe.tar.gz -C /blackfire \
+    && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && fix-permissions /usr/local/etc/php/conf.d/
 
-# ENV BLACKFIRE_VERSION=2.5.2
-# RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
-#     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
-#     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \
-#     && mv /blackfire/blackfire /bin/blackfire \
-#     && chmod +x /bin/blackfire \
-#     && mkdir -p /etc/blackfire \
-#     && touch /etc/blackfire/agent \
-#     && fix-permissions /etc/blackfire/
+ENV BLACKFIRE_VERSION=2.7.0
+RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
+    && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \
+    && mv /blackfire/blackfire /bin/blackfire \
+    && chmod +x /bin/blackfire \
+    && mkdir -p /etc/blackfire \
+    && touch /etc/blackfire/agent \
+    && fix-permissions /etc/blackfire/
 
 RUN mkdir -p /app \
     && fix-permissions /app \


### PR DESCRIPTION
This Updates:

* New Relic PHP Agent to [9.20.0](https://github.com/newrelic/newrelic-php-agent/releases/tag/v9.20.0.310)
* Blackfire Agent to [2.7.0](https://github.com/blackfireio/docker/releases/tag/2.7.0)
* Composer 1 to [1.10.25](https://github.com/composer/composer/releases/tag/1.10.25)
* Drush Launcher to [0.10.1](https://github.com/drush-ops/drush-launcher/releases/tag/0.10.1)

These changes bring more PHP8.1 compatibility (New Relic, Blackfire and Drush Launcher.

It also corrects a couple of issues with the scan-images process
