### PR TITLE
feat: give php-fpm workers 30s to gracefully exit

### DIFF
--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -40,7 +40,7 @@ COPY entrypoints /lagoon/entrypoints/
 
 COPY php.ini /usr/local/etc/php/
 COPY 00-lagoon-php.ini.tpl /usr/local/etc/php/conf.d/
-COPY php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
+COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -40,7 +40,7 @@ COPY entrypoints /lagoon/entrypoints/
 
 COPY php.ini /usr/local/etc/php/
 COPY 00-lagoon-php.ini.tpl /usr/local/etc/php/conf.d/
-COPY php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
+COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -40,7 +40,7 @@ COPY entrypoints /lagoon/entrypoints/
 
 COPY php.ini /usr/local/etc/php/
 COPY 00-lagoon-php.ini.tpl /usr/local/etc/php/conf.d/
-COPY php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
+COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 

--- a/images/php-fpm/php-fpm.d/global.conf
+++ b/images/php-fpm/php-fpm.d/global.conf
@@ -1,0 +1,7 @@
+[global]
+
+; Time limit for child processes to wait for a reaction on signals from master.
+; Available units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+process_control_timeout = 30s

--- a/images/php-fpm/php-fpm.d/www.conf
+++ b/images/php-fpm/php-fpm.d/www.conf
@@ -1,3 +1,11 @@
+[global]
+
+; Time limit for child processes to wait for a reaction on signals from master.
+; Available units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+process_control_timeout = 30s
+
 ; Start a new pool named 'www'.
 ; the variable $pool can we used in any directive and will be replaced by the
 ; pool name ('www' here)

--- a/images/php-fpm/php-fpm.d/www.conf
+++ b/images/php-fpm/php-fpm.d/www.conf
@@ -1,11 +1,3 @@
-[global]
-
-; Time limit for child processes to wait for a reaction on signals from master.
-; Available units: s(econds), m(inutes), h(ours), or d(ays)
-; Default Unit: seconds
-; Default Value: 0
-process_control_timeout = 30s
-
 ; Start a new pool named 'www'.
 ; the variable $pool can we used in any directive and will be replaced by the
 ; pool name ('www' here)


### PR DESCRIPTION
This avoids exiting immediately and returning an error for in-flight web
requests.

Closes: #444 

See this repo for a way to test this locally: https://github.com/smlx/test-php-fpm-graceful-exit