### PR TITLE
Implementing MAXMEMORYPOLICY for redis images

### DIFF
--- a/images/redis/conf/redis.conf
+++ b/images/redis/conf/redis.conf
@@ -5,7 +5,7 @@ loglevel ${LOGLEVEL:-notice}
 databases ${DATABASES:-1}
 
 maxmemory ${MAXMEMORY:-100mb}
-maxmemory-policy allkeys-lru
+maxmemory-policy ${MAXMEMORYPOLICY:-allkeys-lru}
 
 # allow other hosts to connect to us
 protected-mode no


### PR DESCRIPTION
This PR implements the ability to configure redis' `maxmemory-policy` setting via the new `MAXMEMORYPOLICY` variable.

Partially fulfills #476 