### PR TITLE
Added security.txt support.

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -120,6 +120,14 @@ server {
     log_not_found off;
   }
 
+  ## Support for the securitytxt module
+  ## http://drupal.org/project/securitytxt.
+  ## RFC8615 standard path.
+  location = /.well-known/security.txt {
+    access_log off;
+    try_files $uri @drupal;
+  }
+
   ## Support for the robotstxt module
   ## http://drupal.org/project/robotstxt.
   location = /robots.txt {

--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -123,7 +123,7 @@ server {
   ## Support for the securitytxt module
   ## http://drupal.org/project/securitytxt.
   ## RFC8615 standard path.
-  location = /.well-known/security.txt {
+  location ~* ^/\.well-known/security\.txt(\.sig)?$ {
     access_log off;
     try_files $uri @drupal;
   }


### PR DESCRIPTION
Allows access to security.txt (file on disk or provided via the securitytxt module) on the RFC8615 standard path.