### PR TITLE
Add more PHP pacakges and extensions to renovate management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
       "fileMatch": ["(^|/|\\.)Dockerfile$"],
       "matchStrings": ["pecl install -f apcu-(?<currentValue>.*?) "],
       "depNameTemplate": "krakjoe/apcu",
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-releases"
     },
     {
       "fileMatch": ["(^|/|\\.)Dockerfile$"],
@@ -45,6 +45,28 @@
       "matchStrings": ["pecl install -f yaml-(?<currentValue>.*?) "],
       "depNameTemplate": "php/pecl-file_formats-yaml",
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["ENV BLACKFIRE_VERSION=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "blackfireio/docker",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["ENV NEWRELIC_VERSION=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "newrelic/newrelic-php-agent",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["curl.*https://github.com/(?<depName>.*?)/releases/download/(?<currentValue>.*?)/.*.phar.*\n"],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$"],
+      "matchStrings": ["php.*--require=(?<depName>.*?):(?<currentValue>.*?)\\s.*\n"],
+      "datasourceTemplate": "packagist"
     }
   ],
   "packageRules": [
@@ -65,6 +87,19 @@
         "github-releases",
         "github-tags"
       ],
+      "matchPackageNames": [
+        "newrelic/newrelic-php-agent"
+      ],
+      "extractVersion": "^v(?<version>.*)$",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)$"
+    },
+    { 
+      "enabled": true,
+      "matchDatasources": [
+        "github-releases",
+        "github-tags",
+        "packagist"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"
@@ -73,15 +108,21 @@
         "Imagick/imagick",
         "phpredis/phpredis",
         "xdebug/xdebug",
-        "php/pecl-file_formats-yaml"
+        "php/pecl-file_formats-yaml",
+        "composer/composer",
+        "drush/drush",
+        "hechoendrupal/drupal-console-launcher",
+        "drush-ops/drush-launcher",
+        "blackfireio/docker"
       ]
     },
     { 
       "enabled": false,
-      "groupName": "Disable PECL major updates",
+      "groupName": "Disable PHP package/extension major updates",
       "matchDatasources": [
         "github-releases",
-        "github-tags"
+        "github-tags",
+        "packagist"
       ],
       "matchUpdateTypes": [
         "major"
@@ -91,7 +132,12 @@
         "Imagick/imagick",
         "phpredis/phpredis",
         "xdebug/xdebug",
-        "php/pecl-file_formats-yaml"
+        "php/pecl-file_formats-yaml",
+        "composer/composer",
+        "drush/drush",
+        "hechoendrupal/drupal-console-launcher",
+        "drush-ops/drush-launcher",
+        "blackfireio/docker"
       ]
     },
     {
@@ -117,6 +163,7 @@
     },
     {
       "enabled": false,
+      "groupName": "Disable major and minor updates - packages update only patch",
       "matchDatasources": [
         "docker"
       ],
@@ -148,6 +195,7 @@
     },
     {
       "enabled": false,
+      "groupName": "Disable major releases - packages update only minor",
       "matchDatasources": [
         "docker"
       ],


### PR DESCRIPTION
This PR expands the scope of the packages and extensions that can be under Renovate management:

This also covers:
* Composer v1 and v2
* Drush 8
* Drupal Console
* Drush Launcher
* New Relic PHP agent
* Blackfire.io agent

A separate PR will be submitted to make the dockerfiles compatible with these versions