### PR TITLE
Revert "Update dependency newrelic/newrelic-php-agent to v9.21.0.311"

### DIFF
--- a/images/php-fpm/7.4.Dockerfile
+++ b/images/php-fpm/7.4.Dockerfile
@@ -100,7 +100,7 @@ RUN apk add --no-cache --virtual .devdeps \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.21.0.311
+ENV NEWRELIC_VERSION=9.20.0.310
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -100,7 +100,7 @@ RUN apk add --no-cache --virtual .devdeps \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.21.0.311
+ENV NEWRELIC_VERSION=9.20.0.310
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -99,7 +99,7 @@ RUN apk add --no-cache --virtual .devdeps \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=9.21.0.311
+ENV NEWRELIC_VERSION=9.20.0.310
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \


### PR DESCRIPTION
A new install process will need to be found whilst we work this out - https://github.com/newrelic/newrelic-php-agent/pull/403