### PR TITLE
Add minimum config for xdebug 3

### DIFF
--- a/images/php-fpm/entrypoints/60-php-xdebug.sh
+++ b/images/php-fpm/entrypoints/60-php-xdebug.sh
@@ -27,7 +27,10 @@ if expr "$XDEBUG_ENABLE" : '[Tt][Rr][Uu][Ee]' > /dev/null; then
 
   # Add the found client_host to xdebug.ini
   echo -e "\n\nxdebug.client_host=${DOCKERHOST}" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-
+  # Bare minimum config required for Xdebug 3
+  echo -e "\nxdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  echo -e "\nxdebug.discover_client_host=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  
   if [ ${XDEBUG_LOG+x} ]; then
     echo -e "\n\nxdebug.log=/tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
   fi


### PR DESCRIPTION
Had a problem getting xdebug working at all, and discovered that version 3 has changed the default configuration needed to function.  This PR generates that config with the standard xdebug config.