### PR TITLE
ensure only index.php is matched in nginx drupal.conf

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -11,7 +11,7 @@ server {
 
   ## rewriting /index.php to / because after https://www.drupal.org/node/2599326
   ## autocomplete URLs are forced to go to index.php
-  rewrite ^/index.php / last;
+  rewrite ^/index.php$ / last;
 
   ## The 'default' location.
   location / {


### PR DESCRIPTION
If a user has a index.php.original (example) file - the index.php redirect in drupal.conf greedy matches it.

This PR tidies that logic to ensure that edge cases are properly accounted for.

Note that #490 is a much broader rewrite, and may supersede this eventually.