### PR TITLE
pin glibc to 2.34 and stop upgrading apk packages

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -17,7 +17,6 @@ COPY --from=go-crond /usr/local/bin/go-crond /lagoon/bin/cron
 COPY --from=envplate /usr/local/bin/ep /bin/ep
 
 RUN apk update \
-    && apk upgrade \
     && apk add --no-cache curl tini \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /lagoon/crontabs && fix-permissions /lagoon/crontabs \

--- a/images/node-builder/14.Dockerfile
+++ b/images/node-builder/14.Dockerfile
@@ -26,8 +26,8 @@ RUN apk update \
         wget \
         libpng-dev \
     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
-    && apk add --force-overwrite glibc-2.35-r0.apk \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
+    && apk add glibc-2.34-r0.apk \
     && rm -rf /var/cache/apk/*
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.15/main' >> /etc/apk/repositories \

--- a/images/node-builder/14.Dockerfile
+++ b/images/node-builder/14.Dockerfile
@@ -7,7 +7,6 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 ENV LAGOON=node
 
 RUN apk update \
-    && apk upgrade \
     && apk add --no-cache \
         libstdc++ \
     && apk add --no-cache \

--- a/images/node-builder/16.Dockerfile
+++ b/images/node-builder/16.Dockerfile
@@ -26,9 +26,9 @@ RUN apk update \
         ca-certificates \
         wget \
         libpng-dev \
-    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
-    && apk add --force-overwrite glibc-2.35-r0.apk \
-    && rm -rf /var/cache/apk/*
+        && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+        && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
+        && apk add glibc-2.34-r0.apk \
+        && rm -rf /var/cache/apk/*
 
 CMD ["/bin/docker-sleep"]

--- a/images/node-builder/16.Dockerfile
+++ b/images/node-builder/16.Dockerfile
@@ -7,7 +7,6 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 ENV LAGOON=node
 
 RUN apk update \
-    && apk upgrade \
     && apk add --no-cache \
         libstdc++ \
     && apk add --no-cache \

--- a/images/node-builder/18.Dockerfile
+++ b/images/node-builder/18.Dockerfile
@@ -27,8 +27,8 @@ RUN apk update \
         wget \
         libpng-dev \
     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
-    && apk add --force-overwrite glibc-2.35-r0.apk \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
+    && apk add glibc-2.34-r0.apk \
     && rm -rf /var/cache/apk/*
 
 CMD ["/bin/docker-sleep"]

--- a/images/node-builder/18.Dockerfile
+++ b/images/node-builder/18.Dockerfile
@@ -7,7 +7,6 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 ENV LAGOON=node
 
 RUN apk update \
-    && apk upgrade \
     && apk add --no-cache \
         libstdc++ \
     && apk add --no-cache \

--- a/images/node/14.Dockerfile
+++ b/images/node/14.Dockerfile
@@ -31,7 +31,6 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk update \
-    && apk upgrade \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root

--- a/images/node/16.Dockerfile
+++ b/images/node/16.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:16.17.1-alpine3.16
+FROM node:16.17-alpine3.16
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/16.Dockerfile
+++ b/images/node/16.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:16.17-alpine3.16
+FROM node:16.17.1-alpine3.16
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
@@ -31,7 +31,6 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk update \
-    && apk upgrade \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -31,7 +31,6 @@ ENV TMPDIR=/tmp \
     BASH_ENV=/home/.bashrc
 
 RUN apk update \
-    && apk upgrade \
     && rm -rf /var/cache/apk/*
 
 # Make sure Bower and NPM are allowed to be running as root


### PR DESCRIPTION
in #562 I bumped the glibc version and set a flag to handle a package clash. This unintentionally broke some builds.

To remedy the confluence of issues here,
* We no longer upgrade the apk packages in the nodejs base images we inherit (this is a bad idea anyway, as they have not been tested upstream)
* glibc 2.35 came with more serious configuration implications, that in conjunction with the inadvertent upgrade may render a build non-working.

Going forwards, we wll look to deprecate the use of sgerrand/alpine-pkg-glibc in favor of the alpine-native gcompat package, but this release is just intended to revert to the previous functionality.