### PR TITLE
add varnish-6 user to root group for localdev

### DIFF
--- a/images/varnish/6.Dockerfile
+++ b/images/varnish/6.Dockerfile
@@ -73,7 +73,8 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
 RUN fix-permissions /etc/varnish/ \
     && fix-permissions /var/run/ \
-    && fix-permissions /var/lib/varnish
+    && fix-permissions /var/lib/varnish \
+    && usermod -a -G root varnish
 
 COPY docker-entrypoint /lagoon/entrypoints/70-varnish-entrypoint
 


### PR DESCRIPTION
The varnish user does not have access to the root group, so the docker-entrypoint cannot envplate the vcl files on startup locally. In Lagoon, the `10000` user is a member of the root group, so this works ok.

This PR just adds the root group to the varnish user for use locally.