### PR TITLE
update to rabbit 3.9.24

### DIFF
--- a/helpers/TESTING_dockercompose.md
+++ b/helpers/TESTING_dockercompose.md
@@ -62,8 +62,8 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 # commons Should be running Alpine Linux
 docker-compose exec -T commons sh -c "cat /etc/os-release" | grep "Alpine Linux"
 
-# rabbitmq Should have RabbitMQ running 3.8
-docker-compose exec -T rabbitmq sh -c "rabbitmqctl version" | grep 3.8
+# rabbitmq Should have RabbitMQ running 3.9
+docker-compose exec -T rabbitmq sh -c "rabbitmqctl version" | grep 3.9
 
 # rabbitmq Should have delayed_message_exchange plugin enabled
 docker-compose exec -T rabbitmq sh -c "rabbitmq-plugins list" | grep "E" | grep "delayed_message_exchange"

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 # alpine 3.12 as per https://github.com/docker-library/rabbitmq/blob/master/3.8/alpine/Dockerfile
-FROM rabbitmq:3.8.34-management-alpine
+FROM rabbitmq:3.9.24-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
@@ -13,7 +13,8 @@ ENV RABBITMQ_DEFAULT_USER='guest' \
 
 COPY --from=commons /bin/ep /bin/fix-permissions /bin/
 
-RUN wget -O /plugins/rabbitmq_delayed_message_exchange-3.8.17.ez "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.8.17/rabbitmq_delayed_message_exchange-3.8.17.8f537ac.ez" \
+RUN wget -P /plugins https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.9.0/rabbitmq_delayed_message_exchange-3.9.0.ez \
+    && chown rabbitmq:rabbitmq /plugins/rabbitmq_delayed_message_exchange-* \
     && rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_prometheus;
 
 # Copy startup schema with vhost, users, permissions and policies

--- a/images/rabbitmq/cluster-rabbit.sh
+++ b/images/rabbitmq/cluster-rabbit.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# set the correct permissions on the erlang cookie in case Kubernetes changed it
+if [ -e /var/lib/rabbitmq/.erlang.cookie ]; then
+  echo "setting .erlang.cookie permission correctly"
+	chmod 400 /var/lib/rabbitmq/.erlang.cookie
+fi
 
 # Replace ENV values in definitions.json
 if [ -e /etc/rabbitmq/definitions.json ]; then


### PR DESCRIPTION
As per https://www.rabbitmq.com/versions.html, RabbitMQ 3.8 is now EOL. Over the next couple of monthly releases, we will update the image to 3.11