### PR TITLE
replace sgerrand/glibc with gcompat

### DIFF
--- a/images/node-builder/14.Dockerfile
+++ b/images/node-builder/14.Dockerfile
@@ -17,6 +17,7 @@ RUN apk update \
            file \
            g++ \
            gcc \
+           gcompat \
            git \
            gnupg \
            libgcc \
@@ -25,10 +26,6 @@ RUN apk update \
            make \
            openssl \
            wget \
-    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
-    && apk add \
-           glibc-2.34-r0.apk \
     && rm -rf /var/cache/apk/*
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.15/main' >> /etc/apk/repositories \

--- a/images/node-builder/16.Dockerfile
+++ b/images/node-builder/16.Dockerfile
@@ -17,6 +17,7 @@ RUN apk update \
            file \
            g++ \
            gcc \
+           gcompat \
            git \
            gnupg \
            libgcc \
@@ -26,10 +27,6 @@ RUN apk update \
            openssl \
            python3 \
            wget \
-        && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-        && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
-        && apk add \
-               glibc-2.34-r0.apk \
         && rm -rf /var/cache/apk/*
 
 CMD ["/bin/docker-sleep"]

--- a/images/node-builder/18.Dockerfile
+++ b/images/node-builder/18.Dockerfile
@@ -17,6 +17,7 @@ RUN apk update \
            file \
            g++ \
            gcc \
+           gcompat \
            git \
            gnupg \
            libgcc \
@@ -26,10 +27,6 @@ RUN apk update \
            openssl \
            python3 \
            wget \
-    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
-    && apk add \
-           glibc-2.34-r0.apk \
     && rm -rf /var/cache/apk/*
 
 CMD ["/bin/docker-sleep"]


### PR DESCRIPTION
Recent releases of sgerrand's glibc musl<>glibc compatibility binary aren't installing cleanly in more recent versions of Alpine - as first identified in #571.

This PR replaces that binary with the native alpine gcompat package. This will require more testing prior to rollout.