### PR TITLE
update rabbitmq to 3.10.7

### DIFF
--- a/helpers/TESTING_dockercompose.md
+++ b/helpers/TESTING_dockercompose.md
@@ -63,8 +63,8 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 # commons Should be running Alpine Linux
 docker-compose exec -T commons sh -c "cat /etc/os-release" | grep "Alpine Linux"
 
-# rabbitmq Should have RabbitMQ running 3.9
-docker-compose exec -T rabbitmq sh -c "rabbitmqctl version" | grep 3.9
+# rabbitmq Should have RabbitMQ running 3.10
+docker-compose exec -T rabbitmq sh -c "rabbitmqctl version" | grep 3.10
 
 # rabbitmq Should have delayed_message_exchange plugin enabled
 docker-compose exec -T rabbitmq sh -c "rabbitmq-plugins list" | grep "E" | grep "delayed_message_exchange"

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM rabbitmq:3.9.22-management-alpine
+FROM rabbitmq:3.10.7-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
@@ -12,7 +12,7 @@ ENV RABBITMQ_DEFAULT_USER='guest' \
 
 COPY --from=commons /bin/ep /bin/fix-permissions /bin/
 
-RUN wget -P /plugins https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.9.0/rabbitmq_delayed_message_exchange-3.9.0.ez \
+RUN wget -P /plugins https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.10.2/rabbitmq_delayed_message_exchange-3.10.2.ez \
     && chown rabbitmq:rabbitmq /plugins/rabbitmq_delayed_message_exchange-* \
     && rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange rabbitmq_prometheus;
 


### PR DESCRIPTION
3.10.7 is a matching release to 3.9.22 (i.e. before the Erlang issue that broke arm64 compatibility)