### PR TITLE
add internal-services-test to helpers tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ openshift
 !services/api/src/resources/openshift
 .loopback
 *~
+/helpers/test
+/helpers/node_modules
+/helpers/yarn.lock
+/helpers/package.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ node ('lagoon-images') {
             // sh script: "git submodule add -b php81 https://github.com/lagoon-examples/drupal9-base drupal9-base-php81"
             sh script: "git submodule sync && git submodule update --init"
             sh script: "mkdir -p ./all-images && cp ../helpers/docker-compose.yml ./all-images/ && cp ../helpers/TESTING_dockercompose.md ./all-images/"
-            sh script: "sed -i '/image:/ s/uselagoon/${CI_BUILD_TAG}/' ./all-images/docker-compose.yml"
+            sh script: "sed -i '/image: uselagoon/ s/uselagoon/${CI_BUILD_TAG}/' ./all-images/docker-compose.yml"
             sh script: "yarn install"
             sh script: "yarn generate-tests"
             sh script: "docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ node ('lagoon-images') {
             stage ('running test suite') {
               dir ('tests') {
                 sh script: "grep -rl uselagoon . | xargs sed -i '/^FROM/ s/uselagoon/${CI_BUILD_TAG}/'"
-                sh script: "grep -rl uselagoon . | xargs sed -i '/image:/ s/uselagoon/${CI_BUILD_TAG}/'"
+                sh script: "grep -rl uselagoon . | xargs sed -i '/image: uselagoon/ s/uselagoon/${CI_BUILD_TAG}/'"
                 sh script: "find . -maxdepth 2 -name docker-compose.yml | xargs sed -i -e '/###/d'"
                 sh script: "yarn test:simple", label: "Run simple Drupal tests"
                 sh script: "yarn test:advanced", label: "Run advanced Drupal tests"

--- a/helpers/.env
+++ b/helpers/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=all-images

--- a/helpers/TESTING_dockercompose.md
+++ b/helpers/TESTING_dockercompose.md
@@ -91,7 +91,7 @@ docker-compose exec -T redis-6 sh -c "redis-cli CONFIG GET databases"
 docker-compose exec -T redis-6 sh -c "redis-cli dbsize"
 
 # redis-6 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "Service_Host=redis-6"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "SERVICE_HOST=redis-6"
 docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "LAGOON_TEST_VAR=helpers"
 
 # solr-7 should have a "mycore" Solr core
@@ -113,7 +113,7 @@ docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=R
 docker-compose exec -T solr-8 sh -c "cat /var/solr/data/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 8.
 
 # solr-8 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "Service_Host=solr-8"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "SERVICE_HOST=solr-8"
 docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "LAGOON_TEST_VAR=helpers"
 
 # mariadb-10.4 should be version 10.4 client
@@ -144,8 +144,8 @@ docker-compose exec -T mariadb-10.6 sh -c "mysql -e \'SHOW variables;\'" | grep 
 docker-compose exec -T mariadb-10.6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
 # mariadb-10.6 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/maria" | grep "Service_Host=mariadb-10.6"
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/maria" | grep "LAGOON_TEST_VAR=helpers"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb" | grep "SERVICE_HOST=mariadb-10.6"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb" | grep "LAGOON_TEST_VAR=helpers"
 
 # mongo-4 should be version 4.0 client
 docker-compose exec -T mongo-4 sh -c "mongo --version" | grep "shell version" | grep "v4.0"
@@ -157,7 +157,7 @@ docker-compose exec -T mongo-4 sh -c "mongo --eval \'printjson(db.serverStatus()
 docker-compose exec -T mongo-4 sh -c "mongo --eval \'db.stats()\'" | grep "db" | grep "test"
 
 # mongo-4 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "Service_Host=mongo-4"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "SERVICE_HOST=mongo-4"
 docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "LAGOON_TEST_VAR=helpers"
 
 # postgres-11 should be version 11 client
@@ -199,13 +199,16 @@ docker-compose exec -T postgres-14 bash -c "psql -U lagoon -d lagoon -c \'\\l+ l
 # postgres-15 should be version 15 client
 docker-compose exec -T postgres-15 bash -c "psql --version" | grep "psql" | grep "15."
 
+# postgres-15 should be version 15 client
+docker-compose exec -T postgres-15 bash -c "psql --version" | grep "psql" | grep "15."
+
 # postgres-15 should be version 15 server
 docker-compose exec -T postgres-15 bash -c "psql -U lagoon -d lagoon -c \'SELECT version();\'" | grep "PostgreSQL" | grep "15."
 
 # postgres-15 should have lagoon database
 docker-compose exec -T postgres-15 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
 
-# varnish-6 Check varnish has correct vmods in varnish folder
+# varnish-6 should have correct vmods in varnish folder
 docker-compose exec -T varnish-6 sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_bodyaccess.so
 docker-compose exec -T varnish-6 sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_dynamic.so
 
@@ -301,7 +304,7 @@ docker-compose exec -T commons sh -c "curl opensearch-2:9200" | grep number | gr
 docker-compose exec -T commons sh -c "curl opensearch-2:9200/_cluster/health" | json_pp | grep status | grep green
 
 # opensearch-2 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "Service_Host=opensearch-2"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "SERVICE_HOST=opensearch-2"
 docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "LAGOON_TEST_VAR=helpers"
 
 # elasticsearch-7 should have elasticsearch 7

--- a/helpers/TESTING_dockercompose.md
+++ b/helpers/TESTING_dockercompose.md
@@ -18,13 +18,14 @@ docker-compose down
 docker-compose build && docker-compose up -d
 
 # Ensure database pods are ready to connect
-docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10.4:3306 -timeout 1m
-docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10.5:3306 -timeout 1m
-docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10.6:3306 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-4:3306 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-5:3306 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-6:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-11:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-12:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-13:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-14:5432 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-15:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mongo-4:27017 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://rabbitmq:15672 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://opensearch-2:9200 -timeout 1m
@@ -37,9 +38,9 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # should have all the services we expect
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.4_1
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.5_1
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.6_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10-4_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10-5_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10-6_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mongo-4_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_node-14_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_node-16_1
@@ -48,10 +49,11 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-12_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-13_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-14_1
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3.7_1
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3.8_1
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3.9_1
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3.10_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_postgres-15_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3-7_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3-8_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3-9_1
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_python-3-10_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_rabbitmq_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_redis-5_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_redis-6_1
@@ -81,6 +83,10 @@ docker-compose exec -T redis-5 sh -c "redis-cli CONFIG GET databases"
 # redis-5 should have initialized database
 docker-compose exec -T redis-5 sh -c "redis-cli dbsize"
 
+# redis-5 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis-5" | grep "SERVICE_HOST=redis-5"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis-5" | grep "LAGOON_TEST_VAR=all-images"
+
 # redis-6 should be running Redis v6.0
 docker-compose exec -T redis-6 sh -c "redis-server --version" | grep v=6.
 
@@ -91,8 +97,8 @@ docker-compose exec -T redis-6 sh -c "redis-cli CONFIG GET databases"
 docker-compose exec -T redis-6 sh -c "redis-cli dbsize"
 
 # redis-6 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "SERVICE_HOST=redis-6"
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "LAGOON_TEST_VAR=helpers"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis-6" | grep "SERVICE_HOST=redis-6"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis-6" | grep "LAGOON_TEST_VAR=all-images"
 
 # solr-7 should have a "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-7:8983/solr/admin/cores?action=STATUS\&core=mycore"
@@ -102,6 +108,10 @@ docker-compose exec -T commons sh -c "curl solr-7:8983/solr/admin/cores?action=R
 
 # solr-7 should have solr 7.7 solrconfig in "mycore" core
 docker-compose exec -T solr-7 sh -c "cat /opt/solr/server/solr/mycores/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 7.7
+
+# solr-7 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr-7" | grep "SERVICE_HOST=solr-7"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr-7" | grep "LAGOON_TEST_VAR=all-images"
 
 # solr-8 should have a "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=STATUS\&core=mycore"
@@ -113,39 +123,47 @@ docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=R
 docker-compose exec -T solr-8 sh -c "cat /var/solr/data/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 8.
 
 # solr-8 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "SERVICE_HOST=solr-8"
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "LAGOON_TEST_VAR=helpers"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr-8" | grep "SERVICE_HOST=solr-8"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr-8" | grep "LAGOON_TEST_VAR=all-images"
 
-# mariadb-10.4 should be version 10.4 client
-docker-compose exec -T mariadb-10.4 sh -c "mysql -V" | grep "10.4"
+# mariadb-10-4 should be version 10.4 client
+docker-compose exec -T mariadb-10-4 sh -c "mysql -V" | grep "10.4"
 
-# mariadb-10.4 should be version 10.4 server
-docker-compose exec -T mariadb-10.4 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.4"
+# mariadb-10-4 should be version 10.4 server
+docker-compose exec -T mariadb-10-4 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.4"
 
-# mariadb-10.4 should use default credentials
-docker-compose exec -T mariadb-10.4 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
+# mariadb-10-4 should use default credentials
+docker-compose exec -T mariadb-10-4 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
-# mariadb-10.5 should be version 10.5 client
-docker-compose exec -T mariadb-10.5 sh -c "mysql -V" | grep "10.5"
+# mariadb-10-4 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb-10-4" | grep "SERVICE_HOST=10.4"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb-10-4" | grep "LAGOON_TEST_VAR=all-images"
 
-# mariadb-10.5 should be version 10.5 server
-docker-compose exec -T mariadb-10.5 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.5"
+# mariadb-10-5 should be version 10.5 client
+docker-compose exec -T mariadb-10-5 sh -c "mysql -V" | grep "10.5"
 
-# mariadb-10.5 should use default credentials
-docker-compose exec -T mariadb-10.5 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
+# mariadb-10-5 should be version 10.5 server
+docker-compose exec -T mariadb-10-5 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.5"
 
-# mariadb-10.6 should be version 10.6 client
-docker-compose exec -T mariadb-10.6 sh -c "mysql -V" | grep "10.6"
+# mariadb-10-5 should use default credentials
+docker-compose exec -T mariadb-10-5 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
-# mariadb-10.6 should be version 10.6 server
-docker-compose exec -T mariadb-10.6 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.6"
+# mariadb-10-5 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb-10-5" | grep "SERVICE_HOST=10.5"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb-10-5" | grep "LAGOON_TEST_VAR=all-images"
 
-# mariadb-10.6 should use default credentials
-docker-compose exec -T mariadb-10.6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
+# mariadb-10-6 should be version 10.6 client
+docker-compose exec -T mariadb-10-6 sh -c "mysql -V" | grep "10.6"
 
-# mariadb-10.6 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb" | grep "SERVICE_HOST=mariadb-10.6"
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb" | grep "LAGOON_TEST_VAR=helpers"
+# mariadb-10-6 should be version 10.6 server
+docker-compose exec -T mariadb-10-6 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.6"
+
+# mariadb-10-6 should use default credentials
+docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
+
+# mariadb-10-6 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb-10-6" | grep "SERVICE_HOST=10.6"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb-10-6" | grep "LAGOON_TEST_VAR=all-images"
 
 # mongo-4 should be version 4.0 client
 docker-compose exec -T mongo-4 sh -c "mongo --version" | grep "shell version" | grep "v4.0"
@@ -157,8 +175,8 @@ docker-compose exec -T mongo-4 sh -c "mongo --eval \'printjson(db.serverStatus()
 docker-compose exec -T mongo-4 sh -c "mongo --eval \'db.stats()\'" | grep "db" | grep "test"
 
 # mongo-4 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "SERVICE_HOST=mongo-4"
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "LAGOON_TEST_VAR=helpers"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo-4" | grep "SERVICE_HOST="
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo-4" | grep "LAGOON_TEST_VAR=all"
 
 # postgres-11 should be version 11 client
 docker-compose exec -T postgres-11 bash -c "psql --version" | grep "psql" | grep "11."
@@ -169,6 +187,10 @@ docker-compose exec -T postgres-11 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 # postgres-11 should have lagoon database
 docker-compose exec -T postgres-11 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
 
+# postgres-11 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-11" | grep "SERVICE_HOST=PostgreSQL 11"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-11" | grep "LAGOON_TEST_VAR=all-images"
+
 # postgres-12 should be version 12 client
 docker-compose exec -T postgres-12 bash -c "psql --version" | grep "psql" | grep "12."
 
@@ -177,6 +199,10 @@ docker-compose exec -T postgres-12 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 
 # postgres-12 should have lagoon database
 docker-compose exec -T postgres-12 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
+
+# postgres-12 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-12" | grep "SERVICE_HOST=PostgreSQL 12"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-12" | grep "LAGOON_TEST_VAR=all-images"
 
 # postgres-13 should be version 13 client
 docker-compose exec -T postgres-13 bash -c "psql --version" | grep "psql" | grep "13."
@@ -187,6 +213,10 @@ docker-compose exec -T postgres-13 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 # postgres-13 should have lagoon database
 docker-compose exec -T postgres-13 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
 
+# postgres-13 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-13" | grep "SERVICE_HOST=PostgreSQL 13"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-13" | grep "LAGOON_TEST_VAR=all-images"
+
 # postgres-14 should be version 14 client
 docker-compose exec -T postgres-14 bash -c "psql --version" | grep "psql" | grep "14."
 
@@ -195,6 +225,10 @@ docker-compose exec -T postgres-14 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 
 # postgres-14 should have lagoon database
 docker-compose exec -T postgres-14 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
+
+# postgres-14 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-14" | grep "SERVICE_HOST=PostgreSQL 14"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-14" | grep "LAGOON_TEST_VAR=all-images"
 
 # postgres-15 should be version 15 client
 docker-compose exec -T postgres-15 bash -c "psql --version" | grep "psql" | grep "15."
@@ -207,6 +241,10 @@ docker-compose exec -T postgres-15 bash -c "psql -U lagoon -d lagoon -c \'SELECT
 
 # postgres-15 should have lagoon database
 docker-compose exec -T postgres-15 bash -c "psql -U lagoon -d lagoon -c \'\\l+ lagoon\'" | grep "lagoon"
+
+# postgres-15 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-15" | grep "SERVICE_HOST=PostgreSQL 15"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres-15" | grep "LAGOON_TEST_VAR=all-images"
 
 # varnish-6 should have correct vmods in varnish folder
 docker-compose exec -T varnish-6 sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_bodyaccess.so
@@ -223,49 +261,49 @@ docker-compose exec -T varnish-7 sh -c "ls -la /usr/lib/varnish/vmods" | grep li
 docker-compose exec -T commons sh -c "curl -I varnish-7:8080" | grep "Varnish" | grep "7."
 docker-compose exec -T varnish-7 sh -c "varnishlog -d" | grep User-Agent | grep curl 
 
-# python-3.7 should be version 3.7
-docker-compose exec -T python-3.7 sh -c "python -V" | grep "3.7"
+# python-3-7 should be version 3.7
+docker-compose exec -T python-3-7 sh -c "python -V" | grep "3.7"
 
-# python-3.7 should have basic tools installed
-docker-compose exec -T python-3.7 sh -c "pip list --no-cache-dir" | grep "pip"
-docker-compose exec -T python-3.7 sh -c "pip list --no-cache-dir" | grep "setuptools"
-docker-compose exec -T python-3.7 sh -c "pip list --no-cache-dir" | grep "virtualenv" | grep "16.7.10"
+# python-3-7 should have basic tools installed
+docker-compose exec -T python-3-7 sh -c "pip list --no-cache-dir" | grep "pip"
+docker-compose exec -T python-3-7 sh -c "pip list --no-cache-dir" | grep "setuptools"
+docker-compose exec -T python-3-7 sh -c "pip list --no-cache-dir" | grep "virtualenv" | grep "16.7.10"
 
-# python-3.7 should be serving content
-docker-compose exec -T commons sh -c "curl python-3.7:3000/tmp/test" | grep "Python 3.7"
+# python-3-7 should be serving content
+docker-compose exec -T commons sh -c "curl python-3-7:3000/tmp/test" | grep "Python 3.7"
 
-# python-3.8 should be version 3.8
-docker-compose exec -T python-3.8 sh -c "python -V" | grep "3.8"
+# python-3-8 should be version 3.8
+docker-compose exec -T python-3-8 sh -c "python -V" | grep "3.8"
 
-# python-3.8 should have basic tools installed
-docker-compose exec -T python-3.8 sh -c "pip list --no-cache-dir" | grep "pip"
-docker-compose exec -T python-3.8 sh -c "pip list --no-cache-dir" | grep "setuptools"
-docker-compose exec -T python-3.8 sh -c "pip list --no-cache-dir" | grep "virtualenv" | grep "16.7.10"
+# python-3-8 should have basic tools installed
+docker-compose exec -T python-3-8 sh -c "pip list --no-cache-dir" | grep "pip"
+docker-compose exec -T python-3-8 sh -c "pip list --no-cache-dir" | grep "setuptools"
+docker-compose exec -T python-3-8 sh -c "pip list --no-cache-dir" | grep "virtualenv" | grep "16.7.10"
 
-# python-3.8 should be serving content
-docker-compose exec -T commons sh -c "curl python-3.8:3000/tmp/test" | grep "Python 3.8"
+# python-3-8 should be serving content
+docker-compose exec -T commons sh -c "curl python-3-8:3000/tmp/test" | grep "Python 3.8"
 
-# python-3.9 should be version 3.9
-docker-compose exec -T python-3.9 sh -c "python -V" | grep "3.9"
+# python-3-9 should be version 3.9
+docker-compose exec -T python-3-9 sh -c "python -V" | grep "3.9"
 
-# python-3.9 should have basic tools installed
-docker-compose exec -T python-3.9 sh -c "pip list --no-cache-dir" | grep "pip"
-docker-compose exec -T python-3.9 sh -c "pip list --no-cache-dir" | grep "setuptools"
-docker-compose exec -T python-3.9 sh -c "pip list --no-cache-dir" | grep "virtualenv"
+# python-3-9 should have basic tools installed
+docker-compose exec -T python-3-9 sh -c "pip list --no-cache-dir" | grep "pip"
+docker-compose exec -T python-3-9 sh -c "pip list --no-cache-dir" | grep "setuptools"
+docker-compose exec -T python-3-9 sh -c "pip list --no-cache-dir" | grep "virtualenv"
 
-# python-3.9 should be serving content
-docker-compose exec -T commons sh -c "curl python-3.9:3000/tmp/test" | grep "Python 3.9"
+# python-3-9 should be serving content
+docker-compose exec -T commons sh -c "curl python-3-9:3000/tmp/test" | grep "Python 3.9"
 
-# python-3.10 should be version 3.10
-docker-compose exec -T python-3.10 sh -c "python -V" | grep "3.10"
+# python-3-10 should be version 3.10
+docker-compose exec -T python-3-10 sh -c "python -V" | grep "3.10"
 
-# python-3.10 should have basic tools installed
-docker-compose exec -T python-3.10 sh -c "pip list --no-cache-dir" | grep "pip"
-docker-compose exec -T python-3.10 sh -c "pip list --no-cache-dir" | grep "setuptools"
-docker-compose exec -T python-3.10 sh -c "pip list --no-cache-dir" | grep "virtualenv"
+# python-3-10 should have basic tools installed
+docker-compose exec -T python-3-10 sh -c "pip list --no-cache-dir" | grep "pip"
+docker-compose exec -T python-3-10 sh -c "pip list --no-cache-dir" | grep "setuptools"
+docker-compose exec -T python-3-10 sh -c "pip list --no-cache-dir" | grep "virtualenv"
 
-# python-3.10 should be serving content
-docker-compose exec -T commons sh -c "curl python-3.10:3000/tmp/test" | grep "Python 3.10"
+# python-3-10 should be serving content
+docker-compose exec -T commons sh -c "curl python-3-10:3000/tmp/test" | grep "Python 3.10"
 
 # node-14 should have Node 14
 docker-compose exec -T node-14 sh -c "node -v" | grep "v14"
@@ -285,17 +323,17 @@ docker-compose exec -T node-18 sh -c "node -v" | grep "v18"
 # node-18 should be serving content
 docker-compose exec -T commons sh -c "curl node-18:3000/test" | grep "v18"
 
-# ruby-3.0 should have Ruby 3.0
-docker-compose exec -T ruby-3.0 sh -c "ruby -v" | grep "3.0"
+# ruby-3-0 should have Ruby 3.0
+docker-compose exec -T ruby-3-0 sh -c "ruby -v" | grep "3.0"
 
-# ruby-3.0 should be serving content
-docker-compose exec -T commons sh -c "curl ruby-3.0:3000/tmp/" | grep "ruby 3.0"
+# ruby-3-0 should be serving content
+docker-compose exec -T commons sh -c "curl ruby-3-0:3000/tmp/" | grep "ruby 3.0"
 
-# ruby-3.1 should have Ruby 3.1
-docker-compose exec -T ruby-3.1 sh -c "ruby -v" | grep "3.1"
+# ruby-3-1 should have Ruby 3.1
+docker-compose exec -T ruby-3-1 sh -c "ruby -v" | grep "3.1"
 
-# ruby-3.1 should be serving content
-docker-compose exec -T commons sh -c "curl ruby-3.1:3000/tmp/" | grep "ruby 3.1"
+# ruby-3-1 should be serving content
+docker-compose exec -T commons sh -c "curl ruby-3-1:3000/tmp/" | grep "ruby 3.1"
 
 # opensearch-2 should have opensearch 2
 docker-compose exec -T commons sh -c "curl opensearch-2:9200" | grep number | grep "2."
@@ -304,8 +342,8 @@ docker-compose exec -T commons sh -c "curl opensearch-2:9200" | grep number | gr
 docker-compose exec -T commons sh -c "curl opensearch-2:9200/_cluster/health" | json_pp | grep status | grep green
 
 # opensearch-2 should be able to read/write data
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "SERVICE_HOST=opensearch-2"
-docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "LAGOON_TEST_VAR=helpers"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch-2" | grep "SERVICE_HOST=opensearch-2"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch-2" | grep "LAGOON_TEST_VAR=all"
 
 # elasticsearch-7 should have elasticsearch 7
 docker-compose exec -T commons sh -c "curl elasticsearch-7:9200" | grep number | grep "7."

--- a/helpers/TESTING_dockercompose.md
+++ b/helpers/TESTING_dockercompose.md
@@ -9,12 +9,12 @@ Start up tests
 Run the following commands to get up and running with this example.
 
 ```bash
-# Should remove any previous runs and poweroff
+# should remove any previous runs and poweroff
 sed -i -e "/###/d" docker-compose.yml
 docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
 docker-compose down
 
-# Should start up our services successfully
+# should start up our services successfully
 docker-compose build && docker-compose up -d
 
 # Ensure database pods are ready to connect
@@ -36,7 +36,7 @@ Verification commands
 Run the following commands to validate things are rolling as they should.
 
 ```bash
-# Should have all the services we expect
+# should have all the services we expect
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.4_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.5_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_mariadb-10.6_1
@@ -60,53 +60,61 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_varnish-6_1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep all-images_varnish-7_1
 
-# commons Should be running Alpine Linux
+# commons should be running Alpine Linux
 docker-compose exec -T commons sh -c "cat /etc/os-release" | grep "Alpine Linux"
 
-# rabbitmq Should have RabbitMQ running 3.10
+# rabbitmq should have RabbitMQ running 3.10
 docker-compose exec -T rabbitmq sh -c "rabbitmqctl version" | grep 3.10
 
-# rabbitmq Should have delayed_message_exchange plugin enabled
+# rabbitmq should have delayed_message_exchange plugin enabled
 docker-compose exec -T rabbitmq sh -c "rabbitmq-plugins list" | grep "E" | grep "delayed_message_exchange"
 
-# rabbitmq Should have a running RabbitMQ management page running on 15672
+# rabbitmq should have a running RabbitMQ management page running on 15672
 docker-compose exec -T commons sh -c "curl -kL http://rabbitmq:15672" | grep "RabbitMQ Management"
 
-# redis-5 Should be running Redis v5.0
+# redis-5 should be running Redis v5.0
 docker-compose exec -T redis-5 sh -c "redis-server --version" | grep v=5.
 
-# redis-5 Should be able to see databases
+# redis-5 should be able to see databases
 docker-compose exec -T redis-5 sh -c "redis-cli CONFIG GET databases"
 
-# redis-5  databases should be initialized
+# redis-5 should have initialized database
 docker-compose exec -T redis-5 sh -c "redis-cli dbsize"
 
-# redis-6 Should be running Redis v6.0
+# redis-6 should be running Redis v6.0
 docker-compose exec -T redis-6 sh -c "redis-server --version" | grep v=6.
 
-# redis-6 Should be able to see Redis databases
+# redis-6 should be able to see Redis databases
 docker-compose exec -T redis-6 sh -c "redis-cli CONFIG GET databases"
 
-# redis-6 databases should be initialized
+# redis-6 should have initialized database
 docker-compose exec -T redis-6 sh -c "redis-cli dbsize"
 
-# solr-7 Should have a "mycore" Solr core
+# redis-6 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "Service_Host=redis-6"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis" | grep "LAGOON_TEST_VAR=helpers"
+
+# solr-7 should have a "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-7:8983/solr/admin/cores?action=STATUS\&core=mycore"
 
-# solr-7 Should be able to reload "mycore" Solr core
+# solr-7 should be able to reload "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-7:8983/solr/admin/cores?action=RELOAD\&core=mycore"
 
-# solr-7 Check Solr has 7.7 solrconfig in "mycore" core
+# solr-7 should have solr 7.7 solrconfig in "mycore" core
 docker-compose exec -T solr-7 sh -c "cat /opt/solr/server/solr/mycores/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 7.7
 
-# solr-8 Should have a "mycore" Solr core
+# solr-8 should have a "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=STATUS\&core=mycore"
 
-# solr-8 Should be able to reload "mycore" Solr core
+# solr-8 should be able to reload "mycore" Solr core
 docker-compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=RELOAD\&core=mycore"
 
-# solr-8 Check Solr has 8 solrconfig in "mycore" core
+# solr-8 should have solr 8 solrconfig in "mycore" core
 docker-compose exec -T solr-8 sh -c "cat /var/solr/data/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 8.
+
+# solr-8 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "Service_Host=solr-8"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr" | grep "LAGOON_TEST_VAR=helpers"
 
 # mariadb-10.4 should be version 10.4 client
 docker-compose exec -T mariadb-10.4 sh -c "mysql -V" | grep "10.4"
@@ -114,7 +122,7 @@ docker-compose exec -T mariadb-10.4 sh -c "mysql -V" | grep "10.4"
 # mariadb-10.4 should be version 10.4 server
 docker-compose exec -T mariadb-10.4 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.4"
 
-# mariadb-10.4 check default credentials
+# mariadb-10.4 should use default credentials
 docker-compose exec -T mariadb-10.4 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
 # mariadb-10.5 should be version 10.5 client
@@ -123,7 +131,7 @@ docker-compose exec -T mariadb-10.5 sh -c "mysql -V" | grep "10.5"
 # mariadb-10.5 should be version 10.5 server
 docker-compose exec -T mariadb-10.5 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.5"
 
-# mariadb-10.5 check default credentials
+# mariadb-10.5 should use default credentials
 docker-compose exec -T mariadb-10.5 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
 # mariadb-10.6 should be version 10.6 client
@@ -132,17 +140,25 @@ docker-compose exec -T mariadb-10.6 sh -c "mysql -V" | grep "10.6"
 # mariadb-10.6 should be version 10.6 server
 docker-compose exec -T mariadb-10.6 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.6"
 
-# mariadb-10.6 check default credentials
+# mariadb-10.6 should use default credentials
 docker-compose exec -T mariadb-10.6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
-# mongo should be version 4.0 client
+# mariadb-10.6 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/maria" | grep "Service_Host=mariadb-10.6"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/maria" | grep "LAGOON_TEST_VAR=helpers"
+
+# mongo-4 should be version 4.0 client
 docker-compose exec -T mongo-4 sh -c "mongo --version" | grep "shell version" | grep "v4.0"
 
-# mongo should be version 4.0 server
+# mongo-4 should be version 4.0 server
 docker-compose exec -T mongo-4 sh -c "mongo --eval \'printjson(db.serverStatus())\'" | grep "server version" | grep "4.0"
 
-# mongo should have test database
+# mongo-4 should have test database
 docker-compose exec -T mongo-4 sh -c "mongo --eval \'db.stats()\'" | grep "db" | grep "test"
+
+# mongo-4 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "Service_Host=mongo-4"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mongo" | grep "LAGOON_TEST_VAR=helpers"
 
 # postgres-11 should be version 11 client
 docker-compose exec -T postgres-11 bash -c "psql --version" | grep "psql" | grep "11."
@@ -196,7 +212,7 @@ docker-compose exec -T varnish-6 sh -c "ls -la /usr/lib/varnish/vmods" | grep li
 # varnish-6 should be serving pages as version 6
 docker-compose exec -T commons sh -c "curl -I varnish-6:8080" | grep "Varnish" | grep "6."
 
-# varnish-7 Check varnish has correct vmods in varnish folder
+# varnish-7 should have correct vmods in varnish folder
 docker-compose exec -T varnish-7 sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_bodyaccess.so
 docker-compose exec -T varnish-7 sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_dynamic.so
 
@@ -284,6 +300,10 @@ docker-compose exec -T commons sh -c "curl opensearch-2:9200" | grep number | gr
 # opensearch-2 should be healthy
 docker-compose exec -T commons sh -c "curl opensearch-2:9200/_cluster/health" | json_pp | grep status | grep green
 
+# opensearch-2 should be able to read/write data
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "Service_Host=opensearch-2"
+docker-compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/opensearch" | grep "LAGOON_TEST_VAR=helpers"
+
 # elasticsearch-7 should have elasticsearch 7
 docker-compose exec -T commons sh -c "curl elasticsearch-7:9200" | grep number | grep "7."
 
@@ -297,6 +317,6 @@ Destroy tests
 Run the following commands to trash this app like nothing ever happened.
 
 ```bash
-# Should be able to destroy our services with success
+# should be able to destroy our services with success
 docker-compose down --volumes --remove-orphans
 ```

--- a/helpers/docker-compose.yml
+++ b/helpers/docker-compose.yml
@@ -230,7 +230,7 @@ services:
     << : *default-user # uses the defined user from top
 
   internal-services-test:
-    image: tobybellwood/internal-services-test:main
+    image: docker.io/uselagoon/internal-services-test:main
     ports:
       - "3000"
     environment:

--- a/helpers/docker-compose.yml
+++ b/helpers/docker-compose.yml
@@ -228,3 +228,31 @@ services:
     ports:
       - "9200" # exposes the port 8080 with a random local port, find it with `docker-compose port nginx 8080`
     << : *default-user # uses the defined user from top
+
+  internal-services-test:
+    image: tobybellwood/internal-services-test:main
+    ports:
+      - "3000"
+    environment:
+      - LAGOON_TEST_VAR=helpers
+      - MARIADB_HOST=mariadb-10.6
+      - MARIADB_USERNAME=lagoon
+      - MARIADB_PASSWORD=lagoon
+      - MARIADB_DATABASE=lagoon
+      - POSTGRES_HOST=postgres-14
+      - POSTGRES_USERNAME=lagoon
+      - POSTGRES_PASSWORD=lagoon
+      - POSTGRES_DATABASE=lagoon
+      - SOLR_HOST=solr-8
+      - REDIS_HOST=redis-6
+      - OPENSEARCH_HOST=opensearch-2
+      - MONGO_HOST=mongo-4
+      - MONGO_DATABASE=lagoon
+    depends_on:
+      - mariadb-10.6
+      - postgres-14
+      - solr-8
+      - redis-6
+      - opensearch-2
+      - mongo-4
+    << : *default-user # uses the defined user from top

--- a/helpers/docker-compose.yml
+++ b/helpers/docker-compose.yml
@@ -10,19 +10,19 @@ services:
     image: uselagoon/commons:latest
     << : *default-user # uses the defined user from top
 
-  mariadb-10.4:
+  mariadb-10-4:
     image: uselagoon/mariadb-10.4:latest
     ports:
       - "3306"
     << : *default-user # uses the defined user from top
 
-  mariadb-10.5:
+  mariadb-10-5:
     image: uselagoon/mariadb-10.5:latest
     ports:
       - "3306"
     << : *default-user # uses the defined user from top
 
-  mariadb-10.6:
+  mariadb-10-6:
     image: uselagoon/mariadb-10.6:latest
     ports:
       - "3306"
@@ -106,7 +106,7 @@ services:
       - "5432"
     << : *default-user # uses the defined user from top
 
-  python-3.7:
+  python-3-7:
     image: uselagoon/python-3.7:latest
     ports:
       - "3000"
@@ -116,7 +116,7 @@ services:
         exec python -m http.server 3000
         "]
 
-  python-3.8:
+  python-3-8:
     image: uselagoon/python-3.8:latest
     ports:
       - "3000"
@@ -126,7 +126,7 @@ services:
         exec python -m http.server 3000
         "]
 
-  python-3.9:
+  python-3-9:
     image: uselagoon/python-3.9:latest
     ports:
       - "3000"
@@ -136,7 +136,7 @@ services:
         exec python -m http.server 3000
         "]
 
-  python-3.10:
+  python-3-10:
     image: uselagoon/python-3.10:latest
     ports:
       - "3000"
@@ -177,7 +177,7 @@ services:
       - "8983"
     user: solr
 
-  ruby-3.0:
+  ruby-3-0:
     image: uselagoon/ruby-3.0:latest
     ports:
       - "3000"
@@ -187,7 +187,7 @@ services:
         exec ruby -run -e httpd / -p 3000
         "]
 
-  ruby-3.1:
+  ruby-3-1:
     image: uselagoon/ruby-3.1:latest
     ports:
       - "3000"
@@ -204,6 +204,8 @@ services:
     ports:
       - "8080" # exposes the port 8080 with a random local port, find it with `docker-compose port varnish-6 8080`
     << : *default-user # uses the defined user from top
+    depends_on:
+      - nginx
 
   varnish-7:
     image: uselagoon/varnish-7:latest
@@ -212,6 +214,8 @@ services:
     ports:
       - "8080" # exposes the port 8080 with a random local port, find it with `docker-compose port varnish-7 8080`
     << : *default-user # uses the defined user from top
+    depends_on:
+      - nginx
 
   opensearch-2:
     image: uselagoon/opensearch-2:latest
@@ -234,25 +238,5 @@ services:
     ports:
       - "3000"
     environment:
-      - LAGOON_TEST_VAR=helpers
-      - MARIADB_HOST=mariadb-10.6
-      - MARIADB_USERNAME=lagoon
-      - MARIADB_PASSWORD=lagoon
-      - MARIADB_DATABASE=lagoon
-      - POSTGRES_HOST=postgres-14
-      - POSTGRES_USERNAME=lagoon
-      - POSTGRES_PASSWORD=lagoon
-      - POSTGRES_DATABASE=lagoon
-      - SOLR_HOST=solr-8
-      - REDIS_HOST=redis-6
-      - OPENSEARCH_HOST=opensearch-2
-      - MONGO_HOST=mongo-4
-      - MONGO_DATABASE=lagoon
-    depends_on:
-      - mariadb-10.6
-      - postgres-14
-      - solr-8
-      - redis-6
-      - opensearch-2
-      - mongo-4
+      - LAGOON_TEST_VAR=all-images
     << : *default-user # uses the defined user from top


### PR DESCRIPTION
This PR adds an additional service into the helpers tests that allows for easy testing of read/write to various lagoon services