### PR TITLE
Prevent access to composer.json and composer.lock no matter the sub folder

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -27,10 +27,11 @@ server {
     ## Replicate the Apache <FilesMatch> directive of Drupal standard
     ## .htaccess. Disable access to any code files. Return a 404 to curtail
     ## information disclosure.
-    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|.*sql\.gz|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|.*sql\.gz|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|web\.config)$|composer\.(json|lock)$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
       deny all;
       access_log off;
       log_not_found off;
+      return 404;
     }
 
     ## Expiring per default for four weeks and one second, Drupal will overwrite that if necessary


### PR DESCRIPTION
Also return HTTP 404 (this is what the comment indicated should be returned, and I agree).

Fixes #636