### PR TITLE
rollback varnish-7 to 7.1 for arm64 compatibility

### DIFF
--- a/images/varnish/7.Dockerfile
+++ b/images/varnish/7.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM varnish:7.2-alpine
+FROM varnish:7.1-alpine
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
Currently there is no arm v8/64 comaptible varnish 7.2 image
https://hub.docker.com/_/varnish/tags?page=1&name=7.2