### PR TITLE
Revert "Update rabbitmq Docker tag to v3.10.13 (main)"

### DIFF
--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM rabbitmq:3.10.13-management-alpine
+FROM rabbitmq:3.10.6-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION


### PR DESCRIPTION
Reverts uselagoon/lagoon-images#623

This builds natively on ARM64, just not via QEMU. Reverting to test and investigate