### PR TITLE
move security.txt block in nginx-drupal

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -17,6 +17,15 @@ server {
   location / {
     include /etc/nginx/conf.d/drupal/location_prepend*.conf;
 
+    ## This has to come before any *.txt path-based blocking
+    ## Support for the securitytxt module
+    ## http://drupal.org/project/securitytxt.
+    ## RFC8615 standard path.
+    location ~* /\.well-known/security\.txt(\.sig)?$ {
+      access_log off;
+      try_files $uri @drupal;
+    }
+
     ## Do not allow access to .txt and .md unless inside sites/*/files/
     location ~* ^(?!.+sites\/.+\/files\/).+\.(txt|md)$ {
       deny all;
@@ -119,14 +128,6 @@ server {
     deny all;
     access_log off;
     log_not_found off;
-  }
-
-  ## Support for the securitytxt module
-  ## http://drupal.org/project/securitytxt.
-  ## RFC8615 standard path.
-  location ~* ^/\.well-known/security\.txt(\.sig)?$ {
-    access_log off;
-    try_files $uri @drupal;
   }
 
   ## Support for the robotstxt module


### PR DESCRIPTION
in #500, support for the drupal security.txt module was added to nginx-drupal. In practice though, a higher level match procluded access to .txt files outside of the sites/*/files folder.

This PR moves the security.txt block ahead of that block to ensure it processes ahead of it, and additionally removes the restriction on the .well-known folder being in the webroot - which enables the UI file download for signing in multilingual sites.
![image](https://user-images.githubusercontent.com/4373945/210936621-e3c74edf-a3b0-4a6c-8a1f-d7cad897431f.png)
