### PR TITLE
Fix directory permissions to create smaller opensearch-2 image

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -10,7 +10,7 @@ ENV LAGOON=commons
 
 COPY lagoon/ /lagoon/
 RUN mkdir -p /lagoon/bin
-COPY fix-permissions docker-sleep entrypoint-readiness wait-for /bin/
+COPY fix-permissions fix-dir-permissions docker-sleep entrypoint-readiness wait-for /bin/
 COPY .bashrc /home/.bashrc
 
 COPY --from=go-crond /usr/local/bin/go-crond /lagoon/bin/cron

--- a/images/commons/fix-dir-permissions
+++ b/images/commons/fix-dir-permissions
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Fix permissions on the given directory to allow group read/write of
-# regular files and execute of directories.
+# Fix permissions on the given directory to allow group read/write
+# and execute of directories only.
 find -L "$1" -type d -exec chgrp 0 {} +
 find -L "$1" -type d -exec chmod g+rwX {} +

--- a/images/commons/fix-dir-permissions
+++ b/images/commons/fix-dir-permissions
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Fix permissions on the given directory to allow group read/write of
+# regular files and execute of directories.
+find -L "$1" -type d -exec chgrp 0 {} +
+find -L "$1" -type d -exec chmod g+rwX {} +

--- a/images/opensearch/docker-entrypoint.sh
+++ b/images/opensearch/docker-entrypoint.sh
@@ -17,10 +17,9 @@ else
   # Is running in Kubernetes/OpenShift, so find all other pods
   # belonging to the namespace
   echo "Opensearch: Running in Kubernetes, setting up for clustering"
-  K8S_SVC_NAME=$(hostname -f | cut -d"." -f2)
-  echo "Using service name: ${K8S_SVC_NAME}"
+  echo "Using service name: ${HOSTNAME}"
   sed -i 's/discovery.seed_hosts:.*//' /usr/share/opensearch/config/opensearch.yml
   sed -i 's/cluster.initial_cluster_manager_nodes:.*//' /usr/share/opensearch/config/opensearch.yml
-  echo "discovery.seed_hosts: ${K8S_SVC_NAME}" >> /usr/share/opensearch/config/opensearch.yml
-  echo "cluster.initial_cluster_manager_nodes: ${K8S_SVC_NAME}-0" >> /usr/share/opensearch/config/opensearch.yml
+  echo "discovery.seed_hosts: ${HOSTNAME}" >> /usr/share/opensearch/config/opensearch.yml
+  echo "cluster.initial_cluster_manager_nodes: ${HOSTNAME}-0" >> /usr/share/opensearch/config/opensearch.yml
 fi


### PR DESCRIPTION
The current opensearch-2 image is unnecessarily large - this PR uses a new `fix-dir-permissions` command in commons to allow only directories to be permission fixed, reducing the layer size for impacted directories.

In addition, there are a couple of tweaks to the opensearch-2 image to optimise caching - removing the sole dependency on hostname to allow the removal of yum.