### PR TITLE
Additional 3.18 updates to NodeJS

### DIFF
--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -1,6 +1,5 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# Held at 3.17.x to ensure mariadb 10.6 whilst we evaluate upgrade path
 FROM alpine:3.18.0
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"

--- a/images/node/16.Dockerfile
+++ b/images/node/16.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:16.20-alpine3.17
+FROM node:16.20-alpine3.18
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:18.16-alpine3.17
+FROM node:18.16-alpine3.18
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:20.2-alpine3.17
+FROM node:20.2-alpine3.18
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
This adds the NodeJs updates to 3.18 now that they are available.