### PR TITLE
fix: fewer layer changes for opensearch

### DIFF
--- a/images/opensearch/2.Dockerfile
+++ b/images/opensearch/2.Dockerfile
@@ -57,7 +57,9 @@ ENV OPENSEARCH_JAVA_OPTS="-Xms512m -Xmx512m" \
 # Copy es-curl wrapper
 COPY es-curl /usr/share/opensearch/bin/es-curl
 
-RUN fix-permissions /usr/share/opensearch
+RUN fix-permissions /usr/share/opensearch/config \
+      && find /usr/share/opensearch -type d -exec chgrp 0 {} + \
+      && find /usr/share/opensearch -type d -exec chmod g+rwX {} +
 
 USER opensearch
 


### PR DESCRIPTION
Reduce the permission changes to slim the size of the opensearch image.

Before:
![screenshot_2023-06-06-165557](https://github.com/uselagoon/lagoon-images/assets/861778/f227d92c-fcdc-470a-bd3b-ab9b6e0a92f5)

After:
![screenshot_2023-06-06-165630](https://github.com/uselagoon/lagoon-images/assets/861778/41dc3f48-3549-4e80-a078-bdaf3d1fcca6)