### PR TITLE
use ep to create 00-lagoon-php.ini

### DIFF
--- a/images/php-fpm/entrypoints/70-php-config.sh
+++ b/images/php-fpm/entrypoints/70-php-config.sh
@@ -19,7 +19,7 @@
 #
 # @see https://github.com/php/php-src/blob/PHP-8.2/php.ini-production
 
-mv "$PHP_INI_DIR/conf.d/00-lagoon-php.ini.tpl" "$PHP_INI_DIR/conf.d/00-lagoon-php.ini"
-ep "$PHP_INI_DIR/conf.d/00-lagoon-php.ini"
+ep -d "$PHP_INI_DIR/conf.d/00-lagoon-php.ini.tpl" > "$PHP_INI_DIR/conf.d/00-lagoon-php.ini"
 ep /usr/local/etc/php-fpm.conf
 ep /usr/local/etc/php-fpm.d/*
+echo "configured lagoon-php.ini"


### PR DESCRIPTION
This PR uses ep to add the variables/defaults in the 00-lagoon-php.ini file on the entrypoint instead of mv'ing then ep'ing. 

This means it can be run and rerun without error.

closes #783