### PR TITLE
Add mariadb-connector-c package to support mysql8

### DIFF
--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -41,6 +41,7 @@ RUN \
         mariadb-common=~10.11 \
         mariadb-server-utils=~10.11 \
         mariadb=~10.11 \
+        mariadb-connector-c \
         net-tools \
         pwgen \
         tzdata \

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -41,6 +41,7 @@ RUN \
         mariadb-common=~10.4 \
         mariadb-server-utils=~10.4 \
         mariadb=~10.4 \
+        mariadb-connector-c \
         net-tools \
         pwgen \
         tini \

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -41,6 +41,7 @@ RUN \
         mariadb-common=~10.5 \
         mariadb-server-utils=~10.5 \
         mariadb=~10.5 \
+        mariadb-connector-c \
         net-tools \
         pwgen \
         tini \

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -41,6 +41,7 @@ RUN \
         mariadb-common=~10.6 \
         mariadb-server-utils=~10.6 \
         mariadb=~10.6 \
+        mariadb-connector-c \
         net-tools \
         pwgen \
         tini \

--- a/images/node-cli/16.Dockerfile
+++ b/images/node-cli/16.Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache git \
         procps \
         coreutils \
         mariadb-client \
+        mariadb-connector-c \
         postgresql-client \
         mongodb-tools \
         openssh-sftp-server \

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache git \
         procps \
         coreutils \
         mariadb-client \
+        mariadb-connector-c \
         postgresql-client \
         mongodb-tools \
         openssh-sftp-server \

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache git \
         procps \
         coreutils \
         mariadb-client \
+        mariadb-connector-c \
         postgresql-client \
         mongodb-tools \
         openssh-sftp-server \

--- a/images/php-cli/8.0.Dockerfile
+++ b/images/php-cli/8.0.Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache git \
         findutils \
         gzip  \
         mariadb-client \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs-current=~18 \
         npm \

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache git \
         findutils \
         gzip  \
         mariadb-client \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs-dev=~18 \
         npm \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache git \
         findutils \
         gzip  \
         mariadb-client \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs=~18 \
         npm \


### PR DESCRIPTION
To support the new default authentication method in mysql8 `caching_sha2_password`, this adds a client library in case users need to communicate with mysql8 servers