### PR TITLE
force update php-based images curl to 8.4.0

### DIFF
--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -106,6 +106,10 @@ RUN apk add --no-cache --virtual .devdeps \
            tidyhtml \
            yaml
 
+RUN apk update \
+    && apk add --no-cache \
+        curl=~8.4 \
+        libcurl=~8.4
 
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -106,6 +106,11 @@ RUN apk add --no-cache --virtual .devdeps \
            tidyhtml \
            yaml
 
+RUN apk update \
+    && apk add --no-cache \
+        curl=~8.4 \
+        libcurl=~8.4
+
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -106,6 +106,11 @@ RUN apk add --no-cache --virtual .devdeps \
            tidyhtml \
            yaml
 
+RUN apk update \
+    && apk add --no-cache \
+        curl=~8.4 \
+        libcurl=~8.4
+
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements


### PR DESCRIPTION
In the event that upstream PHP images aren't re-released with the curl 8.4.0 update to address CVE-2023-38545 and CVE-2023-38546, this PR introduces a dockerfile step to force upgrade the curl and libcurl versions.

Tracking docker image request at https://github.com/docker-library/php/issues/1449#issuecomment-1758800391