### PR TITLE
use default builder for docker compose tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,6 @@ node ('lagoon-images') {
             sh script: "make docker-buildx-remove", label: "removing leftover buildx"
             sh script: "docker image prune -af", label: "Pruning images"
             sh script: "docker buildx prune -af", label: "Pruning builder cache"
-            sh script: "docker buildx use default", label: "Ensure to use default builder"
           }
         }
 
@@ -96,6 +95,7 @@ node ('lagoon-images') {
           'Run all the tests on the local images': {
             stage ('running test suite') {
               dir ('tests') {
+                sh script: "docker buildx use default", label: "Ensure to use default builder"
                 sh script: "grep -rl uselagoon . | xargs sed -i '/^FROM/ s/uselagoon/${CI_BUILD_TAG}/'"
                 sh script: "grep -rl uselagoon . | xargs sed -i '/image: uselagoon/ s/uselagoon/${CI_BUILD_TAG}/'"
                 sh script: "find . -maxdepth 2 -name docker-compose.yml | xargs sed -i -e '/###/d'"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ node ('lagoon-images') {
             sh script: "make docker-buildx-remove", label: "removing leftover buildx"
             sh script: "docker image prune -af", label: "Pruning images"
             sh script: "docker buildx prune -af", label: "Pruning builder cache"
+            sh script: "docker buildx use default", label: "Ensure to use default builder"
           }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ docker_build_local = DOCKER_BUILDKIT=1 docker build $(DOCKER_BUILD_PARAMS) \
 						-f $(2) $(3)
 
 docker_buildx_two = docker buildx build $(DOCKER_BUILD_PARAMS) \
+						--builder ci-local \
 						--platform linux/amd64,linux/arm64/v8 \
 						--build-arg BUILDKIT_INLINE_CACHE=1 \
 						--build-arg LAGOON_VERSION=$(LAGOON_VERSION) \
@@ -91,6 +92,7 @@ docker_buildx_two = docker buildx build $(DOCKER_BUILD_PARAMS) \
 						-f $(2) $(3)
 
 docker_buildx_three = docker buildx build $(DOCKER_BUILD_PARAMS) \
+						--builder ci-local \
 						--platform linux/amd64,linux/arm64/v8 \
 						--build-arg BUILDKIT_INLINE_CACHE=1 \
 						--build-arg LAGOON_VERSION=$(LAGOON_VERSION) \
@@ -354,7 +356,7 @@ scan-images:
 .PHONY: docker-buildx-configure
 docker-buildx-configure:
 	docker run -d -p 5000:5000 --restart always --name registry registry:2
-	docker buildx create --platform linux/arm64,linux/arm/v8 --driver-opt network=host --name ci-local --use
+	docker buildx create --platform linux/arm64,linux/arm/v8 --driver-opt network=host --name ci-local
 	docker buildx ls
 	docker context ls
 


### PR DESCRIPTION
With the examples updating to docker compose v2, having the images building using buildx was causing the docker compose to also use it for building the examples, resulting in errors.

This PR ensures that the images build in buildx and the examples build in docker