### PR TITLE
remove block pinning curl version

### DIFF
--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -106,11 +106,6 @@ RUN apk add --no-cache --virtual .devdeps \
            tidyhtml \
            yaml
 
-RUN apk update \
-    && apk add --no-cache \
-        curl=~8.4 \
-        libcurl=~8.4
-
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -106,11 +106,6 @@ RUN apk add --no-cache --virtual .devdeps \
            tidyhtml \
            yaml
 
-RUN apk update \
-    && apk add --no-cache \
-        curl=~8.4 \
-        libcurl=~8.4
-
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -106,11 +106,6 @@ RUN apk add --no-cache --virtual .devdeps \
            tidyhtml \
            yaml
 
-RUN apk update \
-    && apk add --no-cache \
-        curl=~8.4 \
-        libcurl=~8.4
-
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements


### PR DESCRIPTION
remove the block added in https://github.com/uselagoon/lagoon-images/pull/847 to pin the curl version after a security release