### PR TITLE
Add PHP8.3 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,12 +182,15 @@ build/rabbitmq-cluster: build/rabbitmq images/rabbitmq-cluster/Dockerfile
 versioned-images := 		php-8.0-fpm \
 							php-8.1-fpm \
 							php-8.2-fpm \
+							php-8.3-fpm \
 							php-8.0-cli \
 							php-8.1-cli \
 							php-8.2-cli \
+							php-8.3-cli \
 							php-8.0-cli-drupal \
 							php-8.1-cli-drupal \
 							php-8.2-cli-drupal \
+							php-8.3-cli-drupal \
 							python-3.8 \
 							python-3.9 \
 							python-3.10 \
@@ -278,13 +281,15 @@ base-images-with-versions += $(experimental-images)
 s3-images += $(versioned-images)
 s3-images += $(experimental-images)
 
-build/php-8.0-fpm build/php-8.1-fpm build/php-8.2-fpm: build/commons
+build/php-8.0-fpm build/php-8.1-fpm build/php-8.2-fpm build/php-8.3-fpm: build/commons
 build/php-8.0-cli: build/php-8.0-fpm
 build/php-8.1-cli: build/php-8.1-fpm
 build/php-8.2-cli: build/php-8.2-fpm
+build/php-8.3-cli: build/php-8.3-fpm
 build/php-8.0-cli-drupal: build/php-8.0-cli
 build/php-8.1-cli-drupal: build/php-8.1-cli
 build/php-8.2-cli-drupal: build/php-8.2-cli
+build/php-8.3-cli-drupal: build/php-8.3-cli
 build/python-3.7 build/python-3.8 build/python-3.9 build/python-3.10 build/python-3.11 build/python-3.12: build/commons
 build/node-18 build/node-20: build/commons
 build/node-18-builder build/node-18-cli: build/node-18

--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -25,6 +25,7 @@ docker-compose build && docker-compose up -d
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://php-8-0-dev:9000 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://php-8-1-dev:9000 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://php-8-2-dev:9000 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://php-8-3-dev:9000 -timeout 1m
 ```
 
 Verification commands
@@ -43,6 +44,8 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-1-prod
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-dev
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-prod
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-3-dev
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-3-prod
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-9
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-10
@@ -180,6 +183,48 @@ docker-compose exec -T commons sh -c "curl -kL http://php-8-2-prod:9000" | grep 
 docker-compose exec -T commons sh -c "curl -kL http://php-8-2-prod:9000" | grep "session.cookie_samesite" | grep "Strict"
 docker-compose exec -T commons sh -c "curl -kL http://php-8-2-prod:9000" | grep "upload_max_filesize" | grep "1024M"
 docker-compose exec -T commons sh -c "curl -kL http://php-8-2-prod:9000" | grep "error_reporting" | grep "22519"
+
+# PHP 8.3 development should have PHP installed
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "PHP Version" | grep "8.3"
+docker-compose exec -T php-8-3-dev bash -c "php -i" | grep "PHP Version" | grep "8.3"
+
+# PHP 8.3 development should have modules enabled
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "APCu Support" | grep "Enabled"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "LibYAML Support" | grep "enabled"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "Redis Support" | grep "enabled"
+# TODO docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "imagick module" | grep "enabled"
+
+# PHP 8.3 development should have default configuration.
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "memory_limit" | grep "400M"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "short_open_tag" | grep "On"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "max_execution_time" | grep "900"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "max_input_time" | grep "900"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "post_max_size" | grep "2048M"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "max_input_vars" | grep "2000"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "max_file_uploads" | grep "20"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "session.cookie_samesite" | grep "no value"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "display_errors" | grep "Off"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "date.timezone" | grep "UTC"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "opcache.memory_consumption" | grep "256"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "error_reporting" | grep "22527"
+docker-compose exec -T php-8-3-dev bash -c "php -i" | grep "sendmail_path" | grep "/usr/sbin/sendmail -t -i"
+
+# PHP 8.3 development should have extensions enabled.
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "xdebug.client_port" | grep "9003"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "PHP_IDE_CONFIG" | grep "serverName=lagoon"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "xdebug.log" | grep "/tmp/xdebug.log"
+# TODO docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "newrelic.appname" | grep "noproject-nobranch"
+# TODO docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "newrelic.application_logging.enabled" | grep "disabled"
+# TODO docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "newrelic.logfile" | grep "/dev/stderr"
+# TODO docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "Blackfire" | grep "enabled"
+# TODO docker-compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "blackfire.agent_socket" | grep "tcp://127.0.0.1:8307"
+
+# PHP 8.3 production should have overridden configuration.
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "max_input_vars" | grep "4000"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "max_file_uploads" | grep "40"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "session.cookie_samesite" | grep "Strict"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "upload_max_filesize" | grep "1024M"
+docker-compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "error_reporting" | grep "22519"
 
 # python-3-8 should be version 3.8
 docker-compose exec -T python-3-8 sh -c "python -V" | grep "3.8"

--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -131,6 +131,39 @@ services:
         exec php -S 0.0.0.0:9000
         "] # runs a webserver with phpinfo output
 
+  php-8-3-dev:
+    image: uselagoon/php-8.3-cli:latest
+    ports:
+      - "9000"
+    environment:
+      - LAGOON_ENVIRONMENT_TYPE=development
+      - XDEBUG_ENABLE=true
+      - XDEBUG_LOG=true
+      # TODO - NEWRELIC_ENABLED=true
+      # TODO - BLACKFIRE_ENABLED=true
+      - NEWRELIC_APPLICATION_LOGGING_ENABLED=false
+    << : *default-user # uses the defined user from top
+    command: ["sh", "-c", "
+        echo PD9waHAKCnBocGluZm8oICk7Cgo/Pg== | base64 -d > /app/index.php;
+        exec php -S 0.0.0.0:9000
+        "] # runs a webserver with phpinfo output
+
+  php-8-3-prod:
+    image: uselagoon/php-8.3-cli:latest
+    ports:
+      - "9000"
+    environment:
+      - LAGOON_ENVIRONMENT_TYPE=production
+      - PHP_MAX_INPUT_VARS=4000
+      - PHP_MAX_FILE_UPLOADS=40
+      - PHP_SESSION_COOKIE_SAMESITE="Strict"
+      - PHP_UPLOAD_MAX_FILESIZE=1024M
+    << : *default-user # uses the defined user from top
+    command: ["sh", "-c", "
+        echo PD9waHAKCnBocGluZm8oICk7Cgo/Pg== | base64 -d > /app/index.php;
+        exec php -S 0.0.0.0:9000
+        "] # runs a webserver with phpinfo output
+
   python-3-8:
     image: uselagoon/python-3.8:latest
     ports:

--- a/images/php-cli-drupal/8.3.Dockerfile
+++ b/images/php-cli-drupal/8.3.Dockerfile
@@ -1,0 +1,11 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/php-8.3-cli
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=cli-drupal
+
+COPY drushrc.php drush.yml /home/.drush/
+
+RUN fix-permissions /home/.drush

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -1,0 +1,65 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/php-8.3-fpm
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=cli
+
+RUN apk add --no-cache git \
+        bash \
+        coreutils \
+        findutils \
+        gzip  \
+        mariadb-client \
+        mariadb-connector-c \
+        mongodb-tools \
+        nodejs-current=~20 \
+        npm \
+        openssh-client \
+        openssh-sftp-server \
+        patch \
+        postgresql-client \
+        procps \
+        rsync \
+        unzip \
+        yarn \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+    && rm -rf /var/cache/apk/*
+
+RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/2.6.5/composer.phar \
+    && chmod +x /usr/local/bin/composer \
+    && mkdir -p /home/.ssh \
+    && fix-permissions /home/
+
+# Adding Composer vendor bin directories to $PATH.
+ENV PATH="/app/vendor/bin:/home/.composer/vendor/bin:$PATH"
+# We not only use "export $PATH" as this could be overwritten again
+# like it happens in /etc/profile of alpine Images.
+
+COPY entrypoints /lagoon/entrypoints/
+
+# Remove warning about running as root in composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Making sure the path is not only added during entrypoint, but also when creating a new shell
+RUN echo "source /lagoon/entrypoints/90-composer-path.sh" >> /home/.bashrc
+# Make sure shells are not running forever
+RUN echo "source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+# Make sure xdebug is automatically enabled also for cli scripts
+RUN echo "source /lagoon/entrypoints/61-php-xdebug-cli-env.sh" >> /home/.bashrc
+# helper functions
+RUN echo "source /lagoon/entrypoints/55-cli-helpers.sh" >> /home/.bashrc
+
+# Copy mariadb-client configuration.
+COPY mariadb-client.cnf /etc/my.cnf.d/
+RUN fix-permissions /etc/my.cnf.d/
+
+# SSH Key and Agent Setup
+COPY ssh_config /etc/ssh/ssh_config
+COPY id_ed25519_lagoon_cli.key /home/.ssh/lagoon_cli.key
+RUN chmod 400 /home/.ssh/lagoon_cli.key
+ENV SSH_AUTH_SOCK=/tmp/ssh-agent
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/bin/docker-sleep"]

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -131,7 +131,9 @@ RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && mv /usr/local/etc/php/conf.d/newrelic.ini /usr/local/etc/php/conf.d/newrelic.disable \
     && cd / && rm -rf /tmp/newrelic \
     && fix-permissions /usr/local/etc/
+
 # Add blackfire probe and agent.
+ENV BLACKFIRE_VERSION=2.23.0
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && mkdir -p /blackfire \
@@ -140,7 +142,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.23.0
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -133,6 +133,7 @@ RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && fix-permissions /usr/local/etc/
 
 # Add blackfire probe and agent.
+ENV BLACKFIRE_VERSION=2.23.0
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && mkdir -p /blackfire \
@@ -141,7 +142,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.23.0
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -133,6 +133,7 @@ RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && fix-permissions /usr/local/etc/
 
 # Add blackfire probe and agent.
+ENV BLACKFIRE_VERSION=2.23.0
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && mkdir -p /blackfire \
@@ -141,7 +142,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && fix-permissions /usr/local/etc/php/conf.d/
 
-ENV BLACKFIRE_VERSION=2.23.0
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -1,0 +1,166 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+
+FROM composer:latest as healthcheckbuilder
+
+RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
+
+FROM php:8.3.0-fpm-alpine3.18
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=php
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+# Copy healthcheck files
+COPY --from=healthcheckbuilder /healthz-php /healthz-php
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+COPY check_fcgi /usr/sbin/
+COPY entrypoints /lagoon/entrypoints/
+
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+COPY 00-lagoon-php.ini.tpl "$PHP_INI_DIR/conf.d/"
+COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
+COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
+COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
+
+RUN apk update \
+    && apk add --no-cache --virtual .devdeps \
+        # for gd
+        freetype-dev \
+        # for gettext
+        gettext-dev \
+        # for imagemagick
+        imagemagick-dev \
+        libgcrypt-dev \
+        # for gd
+        libjpeg-turbo-dev \
+        # for mcrypt
+        libmcrypt-dev \
+        # for gd
+        libpng-dev \
+        # for webp
+        libwebp-dev \
+        # for soap
+        libxml2-dev \
+        # for tidy
+        tidyhtml-dev \
+        # for xdebug
+        linux-headers \
+        # for xsl
+        libxslt-dev \
+        libzip-dev \
+        postgresql-dev \
+        # for yaml
+        yaml-dev \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && yes '' | pecl install -f apcu-5.1.23 \
+    && yes '' | pecl install -f imagick-3.7.0 \
+    && yes '' | pecl install -f redis-5.3.7 \
+    && yes '' | pecl install -f xdebug-3.3.0 \
+    && yes '' | pecl install -f yaml-2.2.3 \
+    && docker-php-ext-enable apcu imagick redis xdebug yaml \
+    && rm -rf /tmp/pear \
+    && apk del -r \
+        .phpize-deps \
+    && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-install -j4 bcmath gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
+    && apk del -r \
+        .devdeps \
+    && apk add --no-cache \
+        fcgi \
+        gettext \
+        icu-libs \
+        imagemagick \
+        imagemagick-libs \
+        libgcrypt \
+        libjpeg-turbo \
+        libmcrypt \
+        libpng \
+        libwebp \
+        libxml2 \
+        libxslt \
+        libzip \
+        postgresql-libs \
+        ssmtp \
+        tidyhtml \
+        yaml \
+    && rm -rf /var/cache/apk/*
+
+# New Relic PHP Agent.
+# @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
+# @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
+ENV NEWRELIC_VERSION=10.14.0.3
+# TODO RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
+#     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
+#     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
+#     && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
+#     && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.browser_monitoring.auto_instrument = .*/newrelic.browser_monitoring.auto_instrument = \${NEWRELIC_BROWSER_MONITORING_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.distributed_tracing_enabled = .*/newrelic.distributed_tracing_enabled = \${NEWRELIC_DISTRIBUTED_TRACING_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/newrelic.license = .*/newrelic.license = \"\${NEWRELIC_LICENSE:-}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.loglevel = .*/newrelic.loglevel = \"\${NEWRELIC_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.daemon.loglevel = .*/newrelic.daemon.loglevel = \"\${NEWRELIC_DAEMON_LOG_LEVEL:-warning}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/newrelic.logfile = .*/newrelic.logfile = \"\/dev\/stderr\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/newrelic.daemon.logfile = .*/newrelic.daemon.logfile = \"\/dev\/stderr\"/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.application_logging.enabled = .*/newrelic.application_logging.enabled = \${NEWRELIC_APPLICATION_LOGGING_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.application_logging.metrics.enabled = .*/newrelic.application_logging.metrics.enabled = \${NEWRELIC_APPLICATION_LOGGING_METRICS_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && sed -i -e "s/;newrelic.application_logging.forwarding.enabled = .*/newrelic.application_logging.forwarding.enabled = \${NEWRELIC_APPLICATION_LOGGING_FORWARDING_ENABLED:-true}/" /usr/local/etc/php/conf.d/newrelic.ini \
+#     && mv /usr/local/etc/php/conf.d/newrelic.ini /usr/local/etc/php/conf.d/newrelic.disable \
+#     && cd / && rm -rf /tmp/newrelic \
+#     && fix-permissions /usr/local/etc/
+
+# Add blackfire probe and agent.
+ENV BLACKFIRE_VERSION=2.23.0
+# TODO version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+#     && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+#     && mkdir -p /blackfire \
+#     && curl -A "Docker" -o /blackfire/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/$architecture/$version \
+#     && tar zxpf /blackfire/blackfire-probe.tar.gz -C /blackfire \
+#     && mv /blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+#     && fix-permissions /usr/local/etc/php/conf.d/
+
+# TODO RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+#     && curl -A "Docker" -o /blackfire/blackfire-linux_${architecture}.tar.gz -D - -L -s https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${architecture}.tar.gz \
+#     && tar zxpf /blackfire/blackfire-linux_${architecture}.tar.gz -C /blackfire \
+#     && mv /blackfire/blackfire /bin/blackfire \
+#     && chmod +x /bin/blackfire \
+#     && mkdir -p /etc/blackfire \
+#     && touch /etc/blackfire/agent \
+#     && fix-permissions /etc/blackfire/
+
+RUN mkdir -p /app \
+    && fix-permissions /app \
+    && fix-permissions /etc/ssmtp/ssmtp.conf \
+    && fix-permissions /usr/local/etc/
+
+EXPOSE 9000
+
+ENV LAGOON_ENVIRONMENT_TYPE=development
+
+WORKDIR /app
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/usr/local/sbin/php-fpm", "-F", "-R"]


### PR DESCRIPTION
This is the first release of PHP8.3 images.

These images are released with a few caveats:
* The included version of nodejs for this image is now v20 - the next release of alpine (3.19) will have a v20 minimum.
* No Blackfire ([promised day 1](https://portal.productboard.com/platformsh/2-what-s-next-at-platform-sh/c/311-php-8-3-support-on-blackfire?utm_medium=social&utm_source=portal_share)) support
* New Relic support yet
* Removed Drupal Console and Drush Launcher and replaced with /app/vendor/bin in the path to pick up composer installed Drush

Note that there may be some issues with enabling Xdebug 3.3.0 (see https://www.drupal.org/project/drupal/issues/3405976)