### PR TITLE
Dockerfile package tidy and add rsync & tar to all images

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# reorganize dockerfile package adds
+37306f3f697d15433085ceb9863e45f168ced87e

--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -18,8 +18,8 @@ COPY --from=envplate /usr/local/bin/ep /bin/ep
 
 RUN apk update \
     && apk add --no-cache \
-           curl \
-           tini \
+        curl \
+        tini \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /lagoon/crontabs && fix-permissions /lagoon/crontabs \
     && ln -s /home/.bashrc /home/.profile

--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=envplate /usr/local/bin/ep /bin/ep
 RUN apk update \
     && apk add --no-cache \
         curl \
+        rsync \
+        tar \
         tini \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /lagoon/crontabs && fix-permissions /lagoon/crontabs \

--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -32,8 +32,8 @@ ENV MARIADB_DATABASE=lagoon \
     MARIADB_PASSWORD=lagoon \
     MARIADB_ROOT_PASSWORD=Lag00n
 
-RUN \
-    apk add --no-cache --virtual .common-run-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .common-run-deps \
         bash \
         curl \
         gettext \
@@ -45,10 +45,11 @@ RUN \
         net-tools \
         pwgen \
         tzdata \
-        wget; \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
-    rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
-    curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+        wget \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/* /var/tmp/* /var/cache/distfiles/* \
+    && rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf* \
+    && curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
 
 COPY entrypoints/ /lagoon/entrypoints/
 COPY mysql-backup.sh /lagoon/

--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -44,6 +44,9 @@ RUN apk update \
         mariadb-connector-c \
         net-tools \
         pwgen \
+        rsync \
+        tar \
+        tini \
         tzdata \
         wget \
     && rm -rf /var/cache/apk/* \

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -32,8 +32,8 @@ ENV MARIADB_DATABASE=lagoon \
     MARIADB_PASSWORD=lagoon \
     MARIADB_ROOT_PASSWORD=Lag00n
 
-RUN \
-    apk add --no-cache --virtual .common-run-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .common-run-deps \
         bash \
         curl \
         gettext \
@@ -46,10 +46,11 @@ RUN \
         pwgen \
         tini \
         tzdata \
-        wget; \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
-    rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
-    curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+        wget \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/* /var/tmp/* /var/cache/distfiles/* \
+    && rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf* \
+    && curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
 
 COPY entrypoints/ /lagoon/entrypoints/
 COPY mysql-backup.sh /lagoon/

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -44,6 +44,8 @@ RUN apk update \
         mariadb-connector-c \
         net-tools \
         pwgen \
+        rsync \
+        tar \
         tini \
         tzdata \
         wget \

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -32,8 +32,8 @@ ENV MARIADB_DATABASE=lagoon \
     MARIADB_PASSWORD=lagoon \
     MARIADB_ROOT_PASSWORD=Lag00n
 
-RUN \
-    apk add --no-cache --virtual .common-run-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .common-run-deps \
         bash \
         curl \
         gettext \
@@ -46,10 +46,11 @@ RUN \
         pwgen \
         tini \
         tzdata \
-        wget; \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
-    rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
-    curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+        wget \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/* /var/tmp/* /var/cache/distfiles/* \
+    && rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf* \
+    && curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
 
 COPY entrypoints/ /lagoon/entrypoints/
 COPY mysql-backup.sh /lagoon/

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -44,6 +44,8 @@ RUN apk update \
         mariadb-connector-c \
         net-tools \
         pwgen \
+        rsync \
+        tar \
         tini \
         tzdata \
         wget \

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -32,8 +32,8 @@ ENV MARIADB_DATABASE=lagoon \
     MARIADB_PASSWORD=lagoon \
     MARIADB_ROOT_PASSWORD=Lag00n
 
-RUN \
-    apk add --no-cache --virtual .common-run-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .common-run-deps \
         bash \
         curl \
         gettext \
@@ -46,10 +46,11 @@ RUN \
         pwgen \
         tini \
         tzdata \
-        wget; \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*; \
-    rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
-    curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+        wget \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/* /var/tmp/* /var/cache/distfiles/* \
+    && rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf* \
+    && curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
 
 COPY entrypoints/ /lagoon/entrypoints/
 COPY mysql-backup.sh /lagoon/

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -44,6 +44,8 @@ RUN apk update \
         mariadb-connector-c \
         net-tools \
         pwgen \
+        rsync \
+        tar \
         tini \
         tzdata \
         wget \

--- a/images/mongo/4.Dockerfile
+++ b/images/mongo/4.Dockerfile
@@ -26,8 +26,10 @@ ENV TMPDIR=/tmp \
 # Alpine 3.9 is the last release of the alpine mongodb package under OS license
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories
-RUN apk update
-RUN apk add mongodb=4.0.5-r0
+RUN apk update \
+    && apk add --no-cache \
+        mongodb=4.0.5-r0 \
+    && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /data/db /data/configdb && \
     fix-permissions /data/db && \

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -30,6 +30,8 @@ ENV TMPDIR=/tmp \
 RUN apk update \
     && apk add --no-cache \
         openssl \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 RUN rm -Rf /etc/nginx && ln -s /usr/local/openresty/nginx/conf /etc/nginx

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -27,8 +27,10 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache \
-        openssl
+RUN apk update \
+    && apk add --no-cache \
+        openssl \
+    && rm -rf /var/cache/apk/*
 
 RUN rm -Rf /etc/nginx && ln -s /usr/local/openresty/nginx/conf /etc/nginx
 

--- a/images/node-builder/18.Dockerfile
+++ b/images/node-builder/18.Dockerfile
@@ -8,25 +8,25 @@ ENV LAGOON=node
 
 RUN apk update \
     && apk add --no-cache \
-           libstdc++ \
+       libstdc++ \
     && apk add --no-cache \
-           bash \
-           binutils-gold \
-           ca-certificates \
-           curl \
-           file \
-           g++ \
-           gcc \
-           gcompat \
-           git \
-           gnupg \
-           libgcc \
-           libpng-dev \
-           linux-headers \
-           make \
-           openssl \
-           python3 \
-           wget \
+       bash \
+       binutils-gold \
+       ca-certificates \
+       curl \
+       file \
+       g++ \
+       gcc \
+       gcompat \
+       git \
+       gnupg \
+       libgcc \
+       libpng-dev \
+       linux-headers \
+       make \
+       openssl \
+       python3 \
+       wget \
     && rm -rf /var/cache/apk/*
 
 CMD ["/bin/docker-sleep"]

--- a/images/node-builder/20.Dockerfile
+++ b/images/node-builder/20.Dockerfile
@@ -8,25 +8,25 @@ ENV LAGOON=node
 
 RUN apk update \
     && apk add --no-cache \
-           libstdc++ \
+       libstdc++ \
     && apk add --no-cache \
-           bash \
-           binutils-gold \
-           ca-certificates \
-           curl \
-           file \
-           g++ \
-           gcc \
-           gcompat \
-           git \
-           gnupg \
-           libgcc \
-           libpng-dev \
-           linux-headers \
-           make \
-           openssl \
-           python3 \
-           wget \
+       bash \
+       binutils-gold \
+       ca-certificates \
+       curl \
+       file \
+       g++ \
+       gcc \
+       gcompat \
+       git \
+       gnupg \
+       libgcc \
+       libpng-dev \
+       linux-headers \
+       make \
+       openssl \
+       python3 \
+       wget \
     && rm -rf /var/cache/apk/*
 
 CMD ["/bin/docker-sleep"]

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -6,23 +6,25 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=node
 
-RUN apk add --no-cache git \
-        unzip \
-        gzip  \
-        bash \
-        openssh-client \
-        rsync \
-        patch \
-        procps \
+RUN apk update \
+    && apk add --no-cache bash \
         coreutils \
+        findutils \
+        git \
+        gzip  \
         mariadb-client \
         mariadb-connector-c \
-        postgresql-client \
         mongodb-tools \
+        openssh-client \
         openssh-sftp-server \
-        findutils \
-    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+        patch \
+        postgresql-client \
+        procps \
+        rsync \
+        tar \
+        unzip \
     && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -6,23 +6,25 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=node
 
-RUN apk add --no-cache git \
-        unzip \
-        gzip  \
-        bash \
-        openssh-client \
-        rsync \
-        patch \
-        procps \
+RUN apk update \
+    && apk add --no-cache bash \
         coreutils \
+        findutils \
+        git \
+        gzip  \
         mariadb-client \
         mariadb-connector-c \
-        postgresql-client \
         mongodb-tools \
+        openssh-client \
         openssh-sftp-server \
-        findutils \
-    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+        patch \
+        postgresql-client \
+        procps \
+        rsync \
+        tar \
+        unzip \
     && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -30,9 +30,6 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk update \
-    && rm -rf /var/cache/apk/*
-
 # Make sure Bower and NPM are allowed to be running as root
 RUN echo '{ "allow_root": true }' > /home/.bowerrc \
     && echo 'unsafe-perm=true' > /home/.npmrc

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -30,9 +30,6 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk update \
-    && rm -rf /var/cache/apk/*
-
 # Make sure Bower and NPM are allowed to be running as root
 RUN echo '{ "allow_root": true }' > /home/.bowerrc \
     && echo 'unsafe-perm=true' > /home/.npmrc

--- a/images/opensearch/2.Dockerfile
+++ b/images/opensearch/2.Dockerfile
@@ -20,6 +20,8 @@ USER root
 RUN dnf update --releasever=latest -y \
     && dnf install -y \
         findutils \
+        rsync \
+        tar \
     && dnf clean all
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \

--- a/images/opensearch/2.Dockerfile
+++ b/images/opensearch/2.Dockerfile
@@ -17,7 +17,10 @@ COPY --from=commons /home /home
 
 USER root
 
-RUN dnf update --releasever=latest -y && dnf install -y findutils && dnf clean all
+RUN dnf update --releasever=latest -y \
+    && dnf install -y \
+        findutils \
+    && dnf clean all
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /usr/sbin/tini && chmod a+x /usr/sbin/tini

--- a/images/php-cli/8.0.Dockerfile
+++ b/images/php-cli/8.0.Dockerfile
@@ -6,7 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=cli
 
-RUN apk add --no-cache git \
+RUN apk update \
+    && apk add --no-cache git \
         bash \
         coreutils \
         findutils \
@@ -24,8 +25,8 @@ RUN apk add --no-cache git \
         rsync \
         unzip \
         yarn \
-    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server
 
 RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/2.6.6/composer.phar \
     && chmod +x /usr/local/bin/composer \

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -6,7 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=cli
 
-RUN apk add --no-cache git \
+RUN apk update \
+    && apk add --no-cache git \
         bash \
         coreutils \
         findutils \
@@ -24,8 +25,8 @@ RUN apk add --no-cache git \
         rsync \
         unzip \
         yarn \
-    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server
 
 RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/2.6.6/composer.phar \
     && chmod +x /usr/local/bin/composer \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -6,7 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=cli
 
-RUN apk add --no-cache git \
+RUN apk update \
+    && apk add --no-cache git \
         bash \
         coreutils \
         findutils \
@@ -24,8 +25,8 @@ RUN apk add --no-cache git \
         rsync \
         unzip \
         yarn \
-    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server
 
 RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/2.6.6/composer.phar \
     && chmod +x /usr/local/bin/composer \

--- a/images/php-fpm/8.0.Dockerfile
+++ b/images/php-fpm/8.0.Dockerfile
@@ -43,7 +43,8 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 
-RUN apk add --no-cache --virtual .devdeps \
+RUN apk update \
+    && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \
         # for gettext
@@ -80,31 +81,32 @@ RUN apk add --no-cache --virtual .devdeps \
     && docker-php-ext-enable apcu imagick redis xdebug yaml \
     && rm -rf /tmp/pear \
     && apk del -r \
-           .phpize-deps \
+        .phpize-deps \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
     && docker-php-ext-install -j4 bcmath gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
-           .devdeps \
+        .devdeps \
     && apk add --no-cache \
-           fcgi \
-           gettext \
-           icu-libs \
-           imagemagick \
-           imagemagick-libs \
-           libgcrypt \
-           libjpeg-turbo \
-           libmcrypt \
-           libpng \
-           libwebp \
-           libxml2 \
-           libxslt \
-           libzip \
-           postgresql-libs \
-           ssmtp \
-           tini \
-           tidyhtml \
-           yaml
+        fcgi \
+        gettext \
+        icu-libs \
+        imagemagick \
+        imagemagick-libs \
+        libgcrypt \
+        libjpeg-turbo \
+        libmcrypt \
+        libpng \
+        libwebp \
+        libxml2 \
+        libxslt \
+        libzip \
+        postgresql-libs \
+        ssmtp \
+        tini \
+        tidyhtml \
+        yaml \
+    && rm -rf /var/cache/apk/*
 
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -44,7 +44,8 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 
-RUN apk add --no-cache --virtual .devdeps \
+RUN apk update \
+    && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \
         # for gettext
@@ -81,30 +82,31 @@ RUN apk add --no-cache --virtual .devdeps \
     && docker-php-ext-enable apcu imagick redis xdebug yaml \
     && rm -rf /tmp/pear \
     && apk del -r \
-           .phpize-deps \
+        .phpize-deps \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
     && docker-php-ext-install -j4 bcmath gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
-           .devdeps \
+        .devdeps \
     && apk add --no-cache \
-           fcgi \
-           gettext \
-           icu-libs \
-           imagemagick \
-           imagemagick-libs \
-           libgcrypt \
-           libjpeg-turbo \
-           libmcrypt \
-           libpng \
-           libwebp \
-           libxml2 \
-           libxslt \
-           libzip \
-           postgresql-libs \
-           ssmtp \
-           tidyhtml \
-           yaml
+        fcgi \
+        gettext \
+        icu-libs \
+        imagemagick \
+        imagemagick-libs \
+        libgcrypt \
+        libjpeg-turbo \
+        libmcrypt \
+        libpng \
+        libwebp \
+        libxml2 \
+        libxslt \
+        libzip \
+        postgresql-libs \
+        ssmtp \
+        tidyhtml \
+        yaml \
+    && rm -rf /var/cache/apk/*
 
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -44,7 +44,8 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 
-RUN apk add --no-cache --virtual .devdeps \
+RUN apk update \
+    && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \
         # for gettext
@@ -81,30 +82,31 @@ RUN apk add --no-cache --virtual .devdeps \
     && docker-php-ext-enable apcu imagick redis xdebug yaml \
     && rm -rf /tmp/pear \
     && apk del -r \
-           .phpize-deps \
+        .phpize-deps \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
     && docker-php-ext-install -j4 bcmath gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
-           .devdeps \
+        .devdeps \
     && apk add --no-cache \
-           fcgi \
-           gettext \
-           icu-libs \
-           imagemagick \
-           imagemagick-libs \
-           libgcrypt \
-           libjpeg-turbo \
-           libmcrypt \
-           libpng \
-           libwebp \
-           libxml2 \
-           libxslt \
-           libzip \
-           postgresql-libs \
-           ssmtp \
-           tidyhtml \
-           yaml
+        fcgi \
+        gettext \
+        icu-libs \
+        imagemagick \
+        imagemagick-libs \
+        libgcrypt \
+        libjpeg-turbo \
+        libmcrypt \
+        libpng \
+        libwebp \
+        libxml2 \
+        libxslt \
+        libzip \
+        postgresql-libs \
+        ssmtp \
+        tidyhtml \
+        yaml \
+    && rm -rf /var/cache/apk/*
 
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/

--- a/images/postgres/11.Dockerfile
+++ b/images/postgres/11.Dockerfile
@@ -22,6 +22,12 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 

--- a/images/postgres/12.Dockerfile
+++ b/images/postgres/12.Dockerfile
@@ -22,6 +22,12 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 

--- a/images/postgres/13.Dockerfile
+++ b/images/postgres/13.Dockerfile
@@ -22,6 +22,12 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 

--- a/images/postgres/14.Dockerfile
+++ b/images/postgres/14.Dockerfile
@@ -22,6 +22,12 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 

--- a/images/postgres/15.Dockerfile
+++ b/images/postgres/15.Dockerfile
@@ -22,6 +22,12 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 

--- a/images/postgres/16.Dockerfile
+++ b/images/postgres/16.Dockerfile
@@ -22,6 +22,12 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
 

--- a/images/python/3.10.Dockerfile
+++ b/images/python/3.10.Dockerfile
@@ -25,12 +25,14 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && pip install --upgrade pip \
     && pip install virtualenv \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.10.Dockerfile
+++ b/images/python/3.10.Dockerfile
@@ -32,6 +32,9 @@ RUN apk update \
     && pip install virtualenv \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/python/3.11.Dockerfile
+++ b/images/python/3.11.Dockerfile
@@ -25,12 +25,14 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && pip install --upgrade pip \
     && pip install virtualenv \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.11.Dockerfile
+++ b/images/python/3.11.Dockerfile
@@ -32,6 +32,9 @@ RUN apk update \
     && pip install virtualenv \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/python/3.12.Dockerfile
+++ b/images/python/3.12.Dockerfile
@@ -25,12 +25,14 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && pip install --upgrade pip \
     && pip install virtualenv \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.12.Dockerfile
+++ b/images/python/3.12.Dockerfile
@@ -32,6 +32,9 @@ RUN apk update \
     && pip install virtualenv \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -32,6 +32,9 @@ RUN apk update \
     && pip install virtualenv==16.7.10 \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -25,12 +25,14 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && pip install --upgrade pip \
     && pip install virtualenv==16.7.10 \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.9.Dockerfile
+++ b/images/python/3.9.Dockerfile
@@ -25,12 +25,14 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && pip install --upgrade pip \
     && pip install virtualenv \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/python/3.9.Dockerfile
+++ b/images/python/3.9.Dockerfile
@@ -32,6 +32,9 @@ RUN apk update \
     && pip install virtualenv \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/rabbitmq-cluster/Dockerfile
+++ b/images/rabbitmq-cluster/Dockerfile
@@ -3,7 +3,6 @@ FROM ${IMAGE_REPO:-lagoon}/rabbitmq
 
 RUN rabbitmq-plugins --offline enable rabbitmq_peer_discovery_k8s
 
-
 ADD enabled_plugins /etc/rabbitmq/enabled_plugins
 ADD rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
 RUN fix-permissions /etc/rabbitmq/rabbitmq.conf

--- a/images/ruby/3.0.Dockerfile
+++ b/images/ruby/3.0.Dockerfile
@@ -34,6 +34,9 @@ RUN apk update \
     && gem install webrick puma bundler \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/ruby/3.0.Dockerfile
+++ b/images/ruby/3.0.Dockerfile
@@ -28,11 +28,13 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && gem install webrick puma bundler \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/ruby/3.1.Dockerfile
+++ b/images/ruby/3.1.Dockerfile
@@ -31,6 +31,9 @@ RUN apk update \
     && gem install webrick puma bundler \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/ruby/3.1.Dockerfile
+++ b/images/ruby/3.1.Dockerfile
@@ -25,11 +25,13 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && gem install webrick puma bundler \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/ruby/3.2.Dockerfile
+++ b/images/ruby/3.2.Dockerfile
@@ -31,6 +31,9 @@ RUN apk update \
     && gem install webrick puma bundler \
     && apk del \
         .build-deps \
+    && apk add --no-cache \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever

--- a/images/ruby/3.2.Dockerfile
+++ b/images/ruby/3.2.Dockerfile
@@ -25,11 +25,13 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
         build-base \
     && gem install webrick puma bundler \
     && apk del \
-           .build-deps
+        .build-deps \
+    && rm -rf /var/cache/apk/*
 
 # Make sure shells are not running forever
 COPY 80-shell-timeout.sh /lagoon/entrypoints/

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get -y update \
     && apt-get -y install \
         busybox \
         curl \
+        rsync \
+        tar \
         zip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/images/solr/7.Dockerfile
+++ b/images/solr/7.Dockerfile
@@ -28,9 +28,9 @@ USER root
 
 RUN apt-get -y update \
     && apt-get -y install \
-                  busybox \
-                  curl \
-                  zip \
+        busybox \
+        curl \
+        zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Mitigation for CVE-2021-45046 and CVE-2021-44228

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get -y update \
     && apt-get -y install \
         busybox \
         curl \
+        rsync \
+        tar \
         zip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -30,9 +30,9 @@ USER root
 
 RUN apt-get -y update \
     && apt-get -y install \
-                  busybox \
-                  curl \
-                  zip \
+        busybox \
+        curl \
+        zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Mitigation for CVE-2021-45046 and CVE-2021-44228 - not needed in log4j-core 2.16.0

--- a/images/varnish/6.Dockerfile
+++ b/images/varnish/6.Dockerfile
@@ -5,31 +5,31 @@ FROM varnish:6.0.12 as vmod
 
 USER root
 RUN apt-get update \
-  && apt-get -y install \
-    build-essential \
-    curl \
-    zip
+    && apt-get -y install \
+        build-essential \
+        curl \
+        zip
 
 RUN curl -s https://packagecloud.io/install/repositories/varnishcache/varnish60lts/script.deb.sh | bash \
-  && apt-get -q update \
-  && apt search varnish \
-  && apt-get -y install \
-    automake \
-    libpcre3-dev \
-    libtool \
-    python3-docutils \
-    varnish=6.0.12-1~bullseye \
-    varnish-dev=6.0.12-1~bullseye
+    && apt-get -q update \
+    && apt search varnish \
+    && apt-get -y install \
+        automake \
+        libpcre3-dev \
+        libtool \
+        python3-docutils \
+        varnish=6.0.12-1~bullseye \
+        varnish-dev=6.0.12-1~bullseye
 
 ENV LIBVMOD_DYNAMIC_VERSION=6.0
 RUN cd /tmp && curl -sSLO https://github.com/nigoroll/libvmod-dynamic/archive/${LIBVMOD_DYNAMIC_VERSION}.zip \
-  && unzip ${LIBVMOD_DYNAMIC_VERSION}.zip && cd libvmod-dynamic-${LIBVMOD_DYNAMIC_VERSION} \
-  && ./autogen.sh && ./configure && make && make install
+    && unzip ${LIBVMOD_DYNAMIC_VERSION}.zip && cd libvmod-dynamic-${LIBVMOD_DYNAMIC_VERSION} \
+    && ./autogen.sh && ./configure && make && make install
 
 ENV VARNISH_MODULES_VERSION=6.0-lts
 RUN cd /tmp && curl -sSLO https://github.com/varnish/varnish-modules/archive/${VARNISH_MODULES_VERSION}.zip \
-  && unzip ${VARNISH_MODULES_VERSION}.zip && cd varnish-modules-${VARNISH_MODULES_VERSION} \
-  && ./bootstrap && ./configure && make && make install
+    && unzip ${VARNISH_MODULES_VERSION}.zip && cd varnish-modules-${VARNISH_MODULES_VERSION} \
+    && ./bootstrap && ./configure && make && make install
 
 FROM varnish:6.0.12
 
@@ -57,8 +57,8 @@ ENV TMPDIR=/tmp \
 USER root
 RUN apt-get -y update \
     && apt-get -y install \
-                  busybox \
-                  curl \
+        busybox \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \


### PR DESCRIPTION
This PR reorganizes the package add steps for all images, fixes minor formatting errors, alphabetizes lists, and ensures that new package lists are fetched, and any caches deleted.

In addition, this PR adds rsync and tar binaries to all images, as these are utilized in the backup and lagoon-sync processes.

The re-org ommit `37306f3f697d15433085ceb9863e45f168ced87e` has been added to the [.git-blame-ignore-revs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) file

closes #169 
closes #51