### PR TITLE
Improve MariaDB performance monitoring settings

### DIFF
--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -163,6 +163,12 @@ docker-compose exec -T mariadb-10-6 sh -c "mysql -V" | grep "10.6"
 # mariadb-10-6 should be version 10.6 server
 docker-compose exec -T mariadb-10-6 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.6"
 
+# mariadb-10-6 should have performance schema and slow logging disabled
+docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "performance_schema" | grep "OFF"
+docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "slow_query_log" | grep "OFF"
+docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "long_query_time" | grep "10"
+docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "log_slow_rate_limit" | grep "1"
+
 # mariadb-10-6 should use default credentials
 docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon
 
@@ -175,6 +181,12 @@ docker-compose exec -T mariadb-10-11 sh -c "mysql -V" | grep "10.11"
 
 # mariadb-10-11 should be version 10.11 server
 docker-compose exec -T mariadb-10-11 sh -c "mysql -e \'SHOW variables;\'" | grep "version" | grep "10.11"
+
+# mariadb-10-11 should have performance schema and slow logging enabled
+docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "performance_schema" | grep "ON"
+docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "slow_query_log" | grep "ON"
+docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "long_query_time" | grep "30"
+docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "log_slow_rate_limit" | grep "5"
 
 # mariadb-10-11 should use default credentials
 docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW databases;\'" | grep lagoon

--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -165,7 +165,7 @@ docker-compose exec -T mariadb-10-6 sh -c "mysql -e \'SHOW variables;\'" | grep 
 
 # mariadb-10-6 should have performance schema and slow logging disabled
 docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "performance_schema" | grep "OFF"
-docker-compose exec -T mariadb-10-11 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "slow_query_log" | grep "OFF"
+docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "slow_query_log" | grep "OFF"
 docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "long_query_time" | grep "10"
 docker-compose exec -T mariadb-10-6 sh -c "mysql -D lagoon -u lagoon --password=lagoon -e \'SHOW GLOBAL VARIABLES;\'" | grep "log_slow_rate_limit" | grep "1"
 

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -32,6 +32,11 @@ services:
     image: uselagoon/mariadb-10.11:latest
     ports:
       - "3306"
+    environment:
+      - MARIADB_PERFORMANCE_SCHEMA=true
+      - MARIADB_LOG_SLOW=true
+      - MARIADB_LONG_QUERY_TIME=30
+      - MARIADB_LOG_SLOW_RATE_LIMIT=5
     << : *default-user # uses the defined user from top
 
   mongo-4:

--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -43,6 +43,7 @@ RUN apk update \
         mariadb=~10.11 \
         mariadb-connector-c \
         net-tools \
+        perl-doc \
         pwgen \
         rsync \
         tar \

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -43,6 +43,7 @@ RUN apk update \
         mariadb=~10.4 \
         mariadb-connector-c \
         net-tools \
+        perl-doc \
         pwgen \
         rsync \
         tar \

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -43,6 +43,7 @@ RUN apk update \
         mariadb=~10.5 \
         mariadb-connector-c \
         net-tools \
+        perl-doc \
         pwgen \
         rsync \
         tar \

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -43,6 +43,7 @@ RUN apk update \
         mariadb=~10.6 \
         mariadb-connector-c \
         net-tools \
+        perl-doc \
         pwgen \
         rsync \
         tar \

--- a/images/mariadb/entrypoints/100-mariadb-logging.bash
+++ b/images/mariadb/entrypoints/100-mariadb-logging.bash
@@ -3,17 +3,20 @@
 set -eo pipefail
 
 if [ -n "$MARIADB_LOG_SLOW" ]; then
-  echo "MARIADB_LOG_SLOW set, logging to /etc/mysql/conf.d/log-slow.cnf"
+  echo "MARIADB_LOG_SLOW set, logging to /var/log/mariadb-slow.log"
   cat <<EOF > /etc/mysql/conf.d/log-slow.cnf
 [mysqld]
+log-output=file
 slow_query_log = 1
 slow_query_log_file = /var/log/mariadb-slow.log
+long_query_time = ${MARIADB_LONG_QUERY_TIME:-10}
+log_slow_rate_limit = ${MARIADB_LOG_SLOW_RATE_LIMIT:1}
 EOF
 fi
 
 
 if [ -n "$MARIADB_LOG_QUERIES" ]; then
-  echo "MARIADB_LOG_QUERIES set, logging to /etc/mysql/conf.d/log-queries.cnf"
+  echo "MARIADB_LOG_QUERIES set, logging to /var/log/mariadb-queries.log"
   cat <<EOF > /etc/mysql/conf.d/log-queries.cnf
 
 [mysqld]

--- a/images/mariadb/entrypoints/100-mariadb-logging.bash
+++ b/images/mariadb/entrypoints/100-mariadb-logging.bash
@@ -10,7 +10,7 @@ log-output=file
 slow_query_log = 1
 slow_query_log_file = /var/log/mariadb-slow.log
 long_query_time = ${MARIADB_LONG_QUERY_TIME:-10}
-log_slow_rate_limit = ${MARIADB_LOG_SLOW_RATE_LIMIT:1}
+log_slow_rate_limit = ${MARIADB_LOG_SLOW_RATE_LIMIT:-1}
 EOF
 fi
 

--- a/images/mariadb/entrypoints/150-mariadb-performance.bash
+++ b/images/mariadb/entrypoints/150-mariadb-performance.bash
@@ -11,3 +11,16 @@ if [ "$LAGOON_ENVIRONMENT_TYPE" == "production" ]; then
     export MARIADB_INNODB_LOG_FILE_SIZE=256M
   fi
 fi
+
+if [ -n "$MARIADB_PERFORMANCE_SCHEMA" ]; then
+  echo "Enabling performance schema"
+  cat <<EOF > /etc/mysql/conf.d/performance-schema.cnf
+[mysqld]
+performance_schema=ON
+performance-schema-instrument='stage/%=ON'
+performance-schema-consumer-events-stages-current=ON
+performance-schema-consumer-events-stages-history=ON
+performance-schema-consumer-events-stages-history-long=ON
+EOF
+
+fi


### PR DESCRIPTION
Fixes:
- Our mariadb images include the `mysqltuner.pl` script but not all the perl packages required to run it

Adds:
- The ability to enable performance schema with `MARIADB_PERFORMANCE_SCHEMA` env var
- The ability to adjust slow query time (`MARIADB_LONG_QUERY_TIME`) and rate limit (`MARIADB_LOG_SLOW_RATE_LIMIT`)