### PR TITLE
revert php 8.1 and 8.3 to alpine 3.18

### DIFF
--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
         mariadb-client \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs-dev=~18 \
+        nodejs-current=~20 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache git \
         mariadb-client \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs=~20 \
+        nodejs-current=~20 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.3.2-fpm-alpine3.19
+FROM php:8.3.2-fpm-alpine3.18
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
There appears to be a segfault bug in recent php docker images. We're still investigating it - this PR reverts to Alpine 3.18 images for now, whilst we sort it out