### PR TITLE
Update php images to alpine3.19 and re-add missing ImageMagick codecs

### DIFF
--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
         mariadb-client \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs-current=~20 \
+        nodejs=~20 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
         mariadb-client \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs-current=~20 \
+        nodejs=~20 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache git \
         mariadb-client \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs-current=~20 \
+        nodejs=~20 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -5,8 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-# php:8.1.26-fpm-alpine3.18 segfaults on alpine 3.19
-FROM php:8.1.27-fpm-alpine3.18
+FROM php:8.1.27-fpm-alpine3.19
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -95,7 +95,16 @@ RUN apk update \
         gettext \
         icu-libs \
         imagemagick \
+        imagemagick-heic \
         imagemagick-libs \
+        imagemagick-jpeg \
+        imagemagick-jxl \
+        imagemagick-pango \
+        imagemagick-pdf \
+        imagemagick-raw \
+        imagemagick-webp \
+        imagemagick-svg \
+        imagemagick-tiff \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.2.16-fpm-alpine3.18
+FROM php:8.2.16-fpm-alpine3.19
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -95,7 +95,16 @@ RUN apk update \
         gettext \
         icu-libs \
         imagemagick \
+        imagemagick-heic \
         imagemagick-libs \
+        imagemagick-jpeg \
+        imagemagick-jxl \
+        imagemagick-pango \
+        imagemagick-pdf \
+        imagemagick-raw \
+        imagemagick-webp \
+        imagemagick-svg \
+        imagemagick-tiff \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.3.3-fpm-alpine3.18
+FROM php:8.3.3-fpm-alpine3.19
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -104,7 +104,16 @@ RUN apk update \
         gettext \
         icu-libs \
         imagemagick \
+        imagemagick-heic \
         imagemagick-libs \
+        imagemagick-jpeg \
+        imagemagick-jxl \
+        imagemagick-pango \
+        imagemagick-pdf \
+        imagemagick-raw \
+        imagemagick-webp \
+        imagemagick-svg \
+        imagemagick-tiff \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \


### PR DESCRIPTION
A change to the imagemagick packaging in alpine 3.19 (source https://gitlab.alpinelinux.org/alpine/aports/-/issues/13415)  seemingly caused an untraceable segfault in the PHP images.

Re-adding the missing imagemagick formats resolves the issue. Note that all previous formats have been re-added.