### PR TITLE
append composer bin dirs to path

### DIFF
--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -33,7 +33,7 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
     && fix-permissions /home/
 
 # Adding Composer vendor bin directories to $PATH.
-ENV PATH="/app/vendor/bin:/home/.composer/vendor/bin:$PATH"
+ENV PATH="$PATH:/app/vendor/bin:/home/.composer/vendor/bin"
 # We not only use "export $PATH" as this could be overwritten again
 # like it happens in /etc/profile of alpine Images.
 


### PR DESCRIPTION
This PR moves the composer bin directories added for PHP9.3 in #877  to the end of the PATH variable, to ensure that any system-wide binaries are considered before any composer-installed ones

closes #934