### PR TITLE
feat: Include Supervisord by default

### DIFF
--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache git \
         postgresql-client \
         procps \
         rsync \
+        supervisor \
         unzip \
         yarn \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \


### PR DESCRIPTION
This includes supervisor as one of the more standard ways of running CLI background jobs in i.e. Laravel apps.