### PR TITLE
include icu-data-full

### DIFF
--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -94,6 +94,7 @@ RUN apk update \
         file \
         gettext \
         icu-libs \
+        icu-data-full \
         imagemagick \
         imagemagick-heic \
         imagemagick-libs \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -94,6 +94,7 @@ RUN apk update \
         file \
         gettext \
         icu-libs \
+        icu-data-full \
         imagemagick \
         imagemagick-heic \
         imagemagick-libs \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -103,6 +103,7 @@ RUN apk update \
         file \
         gettext \
         icu-libs \
+        icu-data-full \
         imagemagick \
         imagemagick-heic \
         imagemagick-libs \


### PR DESCRIPTION
Currenlty the PHP images since #629 have included the INTL module, but not all locales are included in the image and since alpine 3.16.0 only the US and english locales are included by default. This kind of negates the inclusion of intl.

Is it possible to include icu-data-full by default? This is a rather small increase of the image size but would make the images far more usefull ;)