### PR TITLE
Feat: Explicitly set fastcgi_params

### DIFF
--- a/images/nginx/fastcgi.conf
+++ b/images/nginx/fastcgi.conf
@@ -13,6 +13,10 @@ set_by_lua_block $remote_addr_clean {
   end
 }
 
+fastcgi_param  HTTP_X_FORWARDED_FOR     $proxy_add_x_forwarded_for;
+fastcgi_param  HTTP_X_REAL_IP           $remote_addr;
+fastcgi_param  HTTP_X_FORWARDED_PROTO   $scheme;
+
 fastcgi_param  SCRIPT_FILENAME    $realpath_root$fastcgi_script_name;
 fastcgi_param  QUERY_STRING       $query_string;
 fastcgi_param  REQUEST_METHOD     $request_method;


### PR DESCRIPTION
When looking to correctly surface true client IP with a number of reverse proxies in the mix we need access to the `X_FORWARDED_FOR` header in Drupal. With the default configuration this presents as a single IP address for the last hop in the chain:

``` text
$_SERVER['HTTP_X_FORWARDED_FOR']	127.0.0.1 (last hop)
```

With this change we explicitly set `X_FORWARDED_FOR` and other useful request identifiers back via fastcgi_params. This allows us to use `reverse_proxy_addresses` correctly in Drupal (and other applications analogs) to correctly act on the true client IP.

With this change PHP sees the following:

``` text
$_SERVER['HTTP_X_FORWARDED_FOR']	127.0.0.1 (last hop), 1.1.1.1 (remote_addr)
```

`$proxy_add_x_forwarded_for` appends the `remote_addr` to the IP list to allow us to access that information. PHP currently does not see the value set in the `proxy_set_header` and this was the only way I was able to surface this to PHP.