### PR TITLE
Feat: Update log format

### DIFF
--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -16,7 +16,7 @@ http {
     include         /etc/nginx/mime.types;
     default_type    application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    log_format  main  '$http_true_client_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 


### PR DESCRIPTION
The current log format pattern presents log entries that use the last hop IP in 2 places. For example:

```
157.52.110.112 - - [23/Apr/2024:03:53:16 +0000] "GET / HTTP/1.1" 200 64 "-" "StatusCake" "157.52.110.112"
```

`$http_x_forwarded_for` in nginx contains the last IP (or the last trusted IP) from the x_forwarded_for chain contrary to expectation.

> If recursive search is disabled, the original client address that matches one of the trusted addresses is replaced by the last address sent in the request header field defined by the [real_ip_header](https://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header) directive. If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field.

This change allows the true client IP to be be added to the log line so we can do further analysis of the traffic and looks like:

```
<clientip> - - [23/Apr/2024:04:23:44 +0000] "GET / HTTP/1.1" 200 61 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36" "157.52.97.83"
```