### PR TITLE
build: add Node.JS v22 images and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,9 @@ versioned-images := 		php-8.1-fpm \
 							node-20 \
 							node-20-builder \
 							node-20-cli \
+							node-22 \
+							node-22-builder \
+							node-22-cli \
 							solr-8 \
 							solr-8-drupal \
 							solr-9 \
@@ -286,9 +289,10 @@ build/php-8.1-cli-drupal: build/php-8.1-cli
 build/php-8.2-cli-drupal: build/php-8.2-cli
 build/php-8.3-cli-drupal: build/php-8.3-cli
 build/python-3.7 build/python-3.8 build/python-3.9 build/python-3.10 build/python-3.11 build/python-3.12: build/commons
-build/node-18 build/node-20: build/commons
+build/node-18 build/node-20 build/node-22: build/commons
 build/node-18-builder build/node-18-cli: build/node-18
 build/node-20-builder build/node-20-cli: build/node-20
+build/node-22-builder build/node-22-cli: build/node-22
 build/postgres-11 build/postgres-12 build/postgres-13 build/postgres-14 build/postgres-15 build/postgres-16: build/commons
 build/postgres-11-ckan build/postgres-11-drupal: build/postgres-11
 build/postgres-12-drupal: build/postgres-12

--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -37,6 +37,7 @@ Run the following commands to validate things are rolling as they should.
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep commons
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-18
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-20
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-22
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-1-dev
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-1-prod
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-dev
@@ -247,6 +248,12 @@ docker-compose exec -T node-20 sh -c "node -v" | grep "v20"
 
 # node-20 should be serving content
 docker-compose exec -T commons sh -c "curl node-20:3000/test" | grep "v20"
+
+# node-22 should have Node 22
+docker-compose exec -T node-22 sh -c "node -v" | grep "v22"
+
+# node-22 should be serving content
+docker-compose exec -T commons sh -c "curl node-22:3000/test" | grep "v22"
 
 # ruby-3-0 should have Ruby 3.0
 docker-compose exec -T ruby-3-0 sh -c "ruby -v" | grep "3.0"

--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -32,6 +32,17 @@ services:
         exec http-server -p 3000
         "]
 
+  node-22:
+    image: uselagoon/node-22:latest
+    ports:
+      - "3000"
+    user: root
+    command: ["sh", "-c", "
+        npm install -g http-server;
+        node -v | xargs > /app/test.html;
+        exec http-server -p 3000
+        "]
+
   php-8-1-dev:
     image: uselagoon/php-8.1-cli:latest
     ports:

--- a/images/node-builder/22.Dockerfile
+++ b/images/node-builder/22.Dockerfile
@@ -1,0 +1,32 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/node-22
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=node
+
+RUN apk update \
+    && apk add --no-cache \
+       libstdc++ \
+    && apk add --no-cache \
+       bash \
+       binutils-gold \
+       ca-certificates \
+       curl \
+       file \
+       g++ \
+       gcc \
+       gcompat \
+       git \
+       gnupg \
+       libgcc \
+       libpng-dev \
+       linux-headers \
+       make \
+       openssl \
+       python3 \
+       wget \
+    && rm -rf /var/cache/apk/*
+
+CMD ["/bin/docker-sleep"]

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -1,0 +1,49 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/node-22
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=node
+
+RUN apk update \
+    && apk add --no-cache bash \
+        coreutils \
+        findutils \
+        git \
+        gzip  \
+        mariadb-client \
+        mariadb-connector-c \
+        mongodb-tools \
+        openssh-client \
+        openssh-sftp-server \
+        patch \
+        postgresql-client \
+        procps \
+        rsync \
+        tar \
+        unzip \
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+    && mkdir -p /home/.ssh \
+    && fix-permissions /home/
+
+# We not only use "export $PATH" as this could be overwritten again
+# like it happens in /etc/profile of alpine Images.
+COPY entrypoints /lagoon/entrypoints/
+
+# Make sure shells are not running forever
+RUN echo "source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+
+# Copy mariadb-client configuration.
+COPY mariadb-client.cnf /etc/my.cnf.d/
+RUN fix-permissions /etc/my.cnf.d/
+
+# SSH Key and Agent Setup
+COPY ssh_config /etc/ssh/ssh_config
+COPY id_ed25519_lagoon_cli.key /home/.ssh/lagoon_cli.key
+RUN chmod 400 /home/.ssh/lagoon_cli.key
+ENV SSH_AUTH_SOCK=/tmp/ssh-agent
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/bin/docker-sleep"]

--- a/images/node/22.Dockerfile
+++ b/images/node/22.Dockerfile
@@ -1,0 +1,45 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM node:22.0-alpine3.19
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+
+ENV LAGOON=node
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home \
+    && fix-permissions /home \
+    && mkdir -p /app \
+    && fix-permissions /app
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+# Make sure Bower and NPM are allowed to be running as root
+RUN echo '{ "allow_root": true }' > /home/.bowerrc \
+    && echo 'unsafe-perm=true' > /home/.npmrc
+
+WORKDIR /app
+
+EXPOSE 3000
+
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=3000
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["yarn", "run", "start"]


### PR DESCRIPTION
Node.JS 22 was released 2024-04-24 and will be EOL in three years (2027-04-30)

https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule