### PR TITLE
Revert "Explicitly set fastcgi_params"

### DIFF
--- a/images/nginx/fastcgi.conf
+++ b/images/nginx/fastcgi.conf
@@ -13,10 +13,6 @@ set_by_lua_block $remote_addr_clean {
   end
 }
 
-fastcgi_param  HTTP_X_FORWARDED_FOR     $proxy_add_x_forwarded_for;
-fastcgi_param  HTTP_X_REAL_IP           $remote_addr;
-fastcgi_param  HTTP_X_FORWARDED_PROTO   $scheme;
-
 fastcgi_param  SCRIPT_FILENAME    $realpath_root$fastcgi_script_name;
 fastcgi_param  QUERY_STRING       $query_string;
 fastcgi_param  REQUEST_METHOD     $request_method;


### PR DESCRIPTION
This reverts a breaking change to `HTTP_X_FORWARDED_PROTO` introduced in commit fc919ba704325520bd993d60353f60eb3d9050b3.

Closes #987.