### PR TITLE
fix: use correct stop signal in php cli for faster termination

### DIFF
--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -6,6 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=cli
 
+STOPSIGNAL SIGTERM
+
 RUN apk update \
     && apk add --no-cache git \
         bash \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -6,6 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=cli
 
+STOPSIGNAL SIGTERM
+
 RUN apk update \
     && apk add --no-cache git \
         bash \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -6,6 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=cli
 
+STOPSIGNAL SIGTERM
+
 RUN apk add --no-cache git \
         bash \
         coreutils \


### PR DESCRIPTION
The [sleep script](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/docker-sleep#L24) in the commons image checks for the `SIGTERM` signal, but the php-cli images specify `SIGQUIT` which causes unnecessary delay in termination. This PR sets the correct signal for php-cli images.

Tested locally with docker-compose. Before it would wait up to 20 seconds for the `cli` to terminate, after it is practically instant.

Closes #976.