### PR TITLE
fix: don't block txt/md in Drupal private filesystem

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -26,8 +26,9 @@ server {
       try_files $uri @drupal;
     }
 
-    ## Do not allow access to .txt and .md unless inside sites/*/files/
-    location ~* ^(?!.+sites\/.+\/files\/).+\.(txt|md)$ {
+    ## Do not allow access to .txt and .md unless inside public or private files
+    ## directories (sites/*/files and sytem/files)
+    location ~* ^(?!.+(?:sites\/.+|system)\/files\/).+\.(txt|md)$ {
       deny all;
       access_log off;
       log_not_found off;


### PR DESCRIPTION
Changes the regex block of `txt` and `md` files to allow the Drupal private filesystem path `/system/files`.

Closes #924.