### PR TITLE
feat: deprecated lagoon_cli.key and remove from Node 22

### DIFF
--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -41,8 +41,7 @@ RUN fix-permissions /etc/my.cnf.d/
 
 # SSH Key and Agent Setup
 COPY ssh_config /etc/ssh/ssh_config
-COPY id_ed25519_lagoon_cli.key /home/.ssh/lagoon_cli.key
-RUN chmod 400 /home/.ssh/lagoon_cli.key
+RUN sed -i '/# Deprecated: lagoon_cli.key/,+2d' /etc/ssh/ssh_config
 ENV SSH_AUTH_SOCK=/tmp/ssh-agent
 
 ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]

--- a/images/node-cli/ssh_config
+++ b/images/node-cli/ssh_config
@@ -5,5 +5,6 @@ Host *
   ServerAliveInterval 60
   ServerAliveCountMax 1440
 
+# Deprecated: lagoon_cli.key
 Match localuser root
   IdentityFile /home/.ssh/lagoon_cli.key

--- a/images/php-cli/ssh_config
+++ b/images/php-cli/ssh_config
@@ -5,5 +5,6 @@ Host *
   ServerAliveInterval 60
   ServerAliveCountMax 1440
 
+# Deprecated: lagoon_cli.key
 Match localuser root
   IdentityFile /home/.ssh/lagoon_cli.key


### PR DESCRIPTION
Since Node 22 was just released and it's an LTS, hoping we can remove the hardcoded private key since it's only been a few days.

See #735.