### PR TITLE
fix: better APPEND_NATIVE_ENTRYPOINT logic

### DIFF
--- a/images/commons/lagoon/entrypoints.bash
+++ b/images/commons/lagoon/entrypoints.bash
@@ -15,12 +15,8 @@ fi
 # If the image provides a native entrypoint that can, or should, be run after the lagoon endpoints are set, it's path can be
 # set in the APPEND_NATIVE_ENTRYPOINT variable.
 if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
-  if [ -f $APPEND_NATIVE_ENTRYPOINT ]; then
-    echo "running defined endpoint"
-    . $APPEND_NATIVE_ENTRYPOINT
-  else
-    echo "provided native entrypoint file doesn't exist"
-  fi
+  echo "running defined endpoint"
+  . $APPEND_NATIVE_ENTRYPOINT
 fi
 
 exec "$@"

--- a/images/commons/lagoon/entrypoints.bash
+++ b/images/commons/lagoon/entrypoints.bash
@@ -12,4 +12,15 @@ if [ -d /lagoon/entrypoints ]; then
   unset i
 fi
 
+# If the image provides a native entrypoint that can, or should, be run after the lagoon endpoints are set, it's path can be
+# set in the APPEND_NATIVE_ENTRYPOINT variable.
+if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
+  if [ -f $APPEND_NATIVE_ENTRYPOINT ]; then
+    echo "running defined endpoint"
+    . $APPEND_NATIVE_ENTRYPOINT
+  else
+    echo "provided native entrypoint file doesn't exist"
+  fi
+fi
+
 exec "$@"

--- a/images/commons/lagoon/entrypoints.bash
+++ b/images/commons/lagoon/entrypoints.bash
@@ -14,7 +14,7 @@ fi
 
 # If the image provides a native entrypoint that can, or should, be run after the lagoon endpoints are set, it's path can be
 # set in the APPEND_NATIVE_ENTRYPOINT variable.
-if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
+if [ ! -z "${APPEND_NATIVE_ENTRYPOINT+x}" ]; then
   echo "running defined endpoint"
   . $APPEND_NATIVE_ENTRYPOINT
 fi

--- a/images/commons/lagoon/entrypoints.sh
+++ b/images/commons/lagoon/entrypoints.sh
@@ -14,9 +14,12 @@ fi
 
 # If the image provides a native entrypoint that can, or should, be run after the lagoon endpoints are set, it's path can be
 # set in the APPEND_NATIVE_ENTRYPOINT variable.
-if [ -n "$APPEND_NATIVE_ENTRYPOINT" ] && [ -f $APPEND_NATIVE_ENTRYPOINT ]; then
-  echo "running defined endpoint"
-  . $APPEND_NATIVE_ENTRYPOINT
+if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
+  if [ -f $APPEND_NATIVE_ENTRYPOINT ]; then
+    echo "running defined endpoint"
+    . $APPEND_NATIVE_ENTRYPOINT
+  else
+    echo "provided native entrypoint file doesn't exist"
 fi
 
 exec "$@"

--- a/images/commons/lagoon/entrypoints.sh
+++ b/images/commons/lagoon/entrypoints.sh
@@ -15,12 +15,8 @@ fi
 # If the image provides a native entrypoint that can, or should, be run after the lagoon endpoints are set, it's path can be
 # set in the APPEND_NATIVE_ENTRYPOINT variable.
 if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
-  if [ -f $APPEND_NATIVE_ENTRYPOINT ]; then
-    echo "running defined endpoint"
-    . $APPEND_NATIVE_ENTRYPOINT
-  else
-    echo "provided native entrypoint file doesn't exist"
-  fi
+  echo "running defined endpoint"
+  . $APPEND_NATIVE_ENTRYPOINT
 fi
 
 exec "$@"

--- a/images/commons/lagoon/entrypoints.sh
+++ b/images/commons/lagoon/entrypoints.sh
@@ -14,7 +14,7 @@ fi
 
 # If the image provides a native entrypoint that can, or should, be run after the lagoon endpoints are set, it's path can be
 # set in the APPEND_NATIVE_ENTRYPOINT variable.
-if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
+if [ ! -z "${APPEND_NATIVE_ENTRYPOINT+x}" ]; then
   echo "running defined endpoint"
   . $APPEND_NATIVE_ENTRYPOINT
 fi

--- a/images/commons/lagoon/entrypoints.sh
+++ b/images/commons/lagoon/entrypoints.sh
@@ -20,6 +20,7 @@ if [ ! -z "$APPEND_NATIVE_ENTRYPOINT" ]; then
     . $APPEND_NATIVE_ENTRYPOINT
   else
     echo "provided native entrypoint file doesn't exist"
+  fi
 fi
 
 exec "$@"


### PR DESCRIPTION
THis PR fixes the logic in the APPEND_NATIVE_ENTRYPOINT to make sure the variable is set before checking whether the file exists.

it also adds it to the entrypoints.bash for completeness