### PR TITLE
Allow downstream to extend fastcgi params

### DIFF
--- a/images/nginx/fastcgi.conf
+++ b/images/nginx/fastcgi.conf
@@ -13,6 +13,9 @@ set_by_lua_block $remote_addr_clean {
   end
 }
 
+# Allow downstreams to add fastcgi_params.
+include /etc/nginx/fastcgi/*.conf;
+
 fastcgi_param  SCRIPT_FILENAME    $realpath_root$fastcgi_script_name;
 fastcgi_param  QUERY_STRING       $query_string;
 fastcgi_param  REQUEST_METHOD     $request_method;

--- a/images/nginx/fastcgi.conf
+++ b/images/nginx/fastcgi.conf
@@ -13,7 +13,8 @@ set_by_lua_block $remote_addr_clean {
   end
 }
 
-# Allow downstreams to add fastcgi_params.
+# Allow downstreams to add fastcgi_params, usually any values included 
+# this way may be overwritten by the default values below.
 include /etc/nginx/fastcgi/*.conf;
 
 fastcgi_param  SCRIPT_FILENAME    $realpath_root$fastcgi_script_name;


### PR DESCRIPTION
Allow images that inherit from the base nginx image to include files that can extend the fastcgi param configuration. This will allow image consumers to add additional headers. Adding the include above the default params ensures that base configurations override any customisations that are made if required. This ensures that the base images can respond to to CVEs appropriately.
