### PR TITLE
build: deprecate ruby3.0, introduce ruby3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,9 +234,9 @@ versioned-images := 		php-8.1-fpm \
 							varnish-7-drupal \
 							varnish-7-persistent \
 							varnish-7-persistent-drupal \
-							ruby-3.0 \
 							ruby-3.1 \
 							ruby-3.2 \
+							ruby-3.3 \
 							opensearch-2
 
 # default-versioned-images are images that formerly had no versioning, and are made backwards-compatible.

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ build/mariadb-10.4-drupal: build/mariadb-10.4
 build/mariadb-10.5-drupal: build/mariadb-10.5
 build/mariadb-10.6-drupal: build/mariadb-10.6
 build/mariadb-10.11-drupal: build/mariadb-10.11
-build/ruby-3.0 build/ruby-3.1 build/ruby-3.2: build/commons
+build/ruby-3.1 build/ruby-3.2 build/ruby-3.3: build/commons
 build/opensearch-2: build/commons
 build/mongo-4: build/commons 
 

--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -49,9 +49,9 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-10
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-11
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-12
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep ruby-3-0
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep ruby-3-1
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep ruby-3-2
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep ruby-3-3
 
 # commons should be running Alpine Linux
 docker compose exec -T commons sh -c "cat /etc/os-release" | grep "Alpine Linux"
@@ -255,12 +255,6 @@ docker compose exec -T node-22 sh -c "node -v" | grep "v22"
 # node-22 should be serving content
 docker compose exec -T commons sh -c "curl node-22:3000/test" | grep "v22"
 
-# ruby-3-0 should have Ruby 3.0
-docker compose exec -T ruby-3-0 sh -c "ruby -v" | grep "3.0"
-
-# ruby-3-0 should be serving content
-docker compose exec -T commons sh -c "curl ruby-3-0:3000/tmp/" | grep "ruby 3.0"
-
 # ruby-3-1 should have Ruby 3.1
 docker compose exec -T ruby-3-1 sh -c "ruby -v" | grep "3.1"
 
@@ -272,6 +266,12 @@ docker compose exec -T ruby-3-2 sh -c "ruby -v" | grep "3.2"
 
 # ruby-3-2 should be serving content
 docker compose exec -T commons sh -c "curl ruby-3-2:3000/tmp/" | grep "ruby 3.2"
+
+# ruby-3-3 should have Ruby 3.3
+docker compose exec -T ruby-3-3 sh -c "ruby -v" | grep "3.3"
+
+# ruby-3-3 should be serving content
+docker compose exec -T commons sh -c "curl ruby-3-3:3000/tmp/" | grep "ruby 3.3"
 ```
 
 Destroy tests

--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -192,16 +192,6 @@ services:
         exec python -m http.server 3000
         "]
 
-  ruby-3-0:
-    image: uselagoon/ruby-3.0:latest
-    ports:
-      - "3000"
-    << : *default-user # uses the defined user from top
-    command: ["sh", "-c", "
-        ruby -v | xargs > /tmp/index.html;
-        exec ruby -run -e httpd / -p 3000
-        "]
-
   ruby-3-1:
     image: uselagoon/ruby-3.1:latest
     ports:
@@ -214,6 +204,16 @@ services:
 
   ruby-3-2:
     image: uselagoon/ruby-3.2:latest
+    ports:
+      - "3000"
+    << : *default-user # uses the defined user from top
+    command: ["sh", "-c", "
+        ruby -v | xargs > /tmp/index.html;
+        exec ruby -run -e httpd / -p 3000
+        "]
+
+  ruby-3-3:
+    image: uselagoon/ruby-3.3:latest
     ports:
       - "3000"
     << : *default-user # uses the defined user from top

--- a/images/ruby/3.3.Dockerfile
+++ b/images/ruby/3.3.Dockerfile
@@ -1,7 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-# Alpine 3.19 image not available for Ruby 3.0
-FROM ruby:3.0.7-alpine3.16
+FROM ruby:3.3.2-alpine3.19
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
Ruby 3.0 hit EOL in late April, and 3.3 was available in December 2023
https://www.ruby-lang.org/en/downloads/branches/