### PR TITLE
chore: temp pin mariadb versions

### DIFF
--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -37,10 +37,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=~10.11 \
-        mariadb-common=~10.11 \
-        mariadb-server-utils=~10.11 \
-        mariadb=~10.11 \
+        mariadb-client=10.11.6-r0 \
+        mariadb-common=10.11.6-r0 \
+        mariadb-server-utils=10.11.6-r0 \
+        mariadb=10.11.6-r0 \
         mariadb-connector-c \
         net-tools \
         perl-doc \

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -37,10 +37,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=~10.4 \
-        mariadb-common=~10.4 \
-        mariadb-server-utils=~10.4 \
-        mariadb=~10.4 \
+        mariadb-client=10.4.25-r0 \
+        mariadb-common=10.4.25-r0 \
+        mariadb-server-utils=10.4.25-r0 \
+        mariadb=10.4.25-r0 \
         mariadb-connector-c \
         net-tools \
         perl-doc \

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -37,10 +37,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=~10.5 \
-        mariadb-common=~10.5 \
-        mariadb-server-utils=~10.5 \
-        mariadb=~10.5 \
+        mariadb-client=10.5.19-r0 \
+        mariadb-common=10.5.19-r0 \
+        mariadb-server-utils=10.5.19-r0 \
+        mariadb=10.5.19-r0 \
         mariadb-connector-c \
         net-tools \
         perl-doc \

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -37,10 +37,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=~10.6 \
-        mariadb-common=~10.6 \
-        mariadb-server-utils=~10.6 \
-        mariadb=~10.6 \
+        mariadb-client=10.6.16-r0 \
+        mariadb-common=10.6.16-r0 \
+        mariadb-server-utils=10.6.16-r0 \
+        mariadb=10.6.16-r0 \
         mariadb-connector-c \
         net-tools \
         perl-doc \


### PR DESCRIPTION
MariaDB has introduced a breaking change in https://mariadb.org/mariadb-dump-file-compatibility-change/

This PR just pins the mariadb versions to "known good" ones until we work out how to handle this