### PR TITLE
Allow OPTIONS requests when using basic auth

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -41,6 +41,7 @@ COPY fastcgi.conf /etc/nginx/fastcgi.conf
 COPY fastcgi.conf /etc/nginx/fastcgi_params
 COPY helpers/ /etc/nginx/helpers/
 COPY static-files.conf /etc/nginx/conf.d/app.conf
+COPY basic_auth.conf /etc/nginx/conf.d/basic_auth.conf
 COPY redirects-map.conf /etc/nginx/redirects-map.conf
 COPY healthcheck/healthz.locations healthcheck/healthz.locations.php.disable /etc/nginx/conf.d/
 

--- a/images/nginx/basic_auth.conf
+++ b/images/nginx/basic_auth.conf
@@ -1,0 +1,5 @@
+map $request_method $use_basic_auth {
+  # Disable auth on OPTIONS requests, nothing else
+  default "${BASIC_AUTH:-off}";
+  OPTIONS off;
+}

--- a/images/nginx/helpers/020_basic-auth.conf
+++ b/images/nginx/helpers/020_basic-auth.conf
@@ -1,3 +1,3 @@
 # BASIC_AUTH is set during docker-entrypoint if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD are set
-auth_basic "${BASIC_AUTH:-off}";
+auth_basic $use_basic_auth;
 auth_basic_user_file "/etc/nginx/.htpasswd";


### PR DESCRIPTION
Closes #857 

This PR implements a `map` directive that sets a variable which decides whether basic authentication should be enabled or not, based on if the request is an OPTIONS request. If it is not, it will use whatever is set by the BASIC_AUTH environment variable, just like before.

This shouldn't be a breaking change :)