### PR TITLE
build: update images to alpine 3.20

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -1,7 +1,7 @@
 FROM webdevops/go-crond:23.12.0-alpine AS go-crond
 FROM amazeeio/envplate:v1.0.3 AS envplate
 
-FROM alpine:3.19.3
+FROM alpine:3.20.2
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/mongo/4.Dockerfile
+++ b/images/mongo/4.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM alpine:3.19.3
+FROM alpine:3.20.2
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -6,14 +6,12 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=node
 
-RUN apk update \
+RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
     && apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
-        mariadb-client \
-        mariadb-connector-c \
         mongodb-tools \
         openssh-client \
         openssh-sftp-server \

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -6,14 +6,12 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=node
 
-RUN apk update \
+RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
     && apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
-        mariadb-client \
-        mariadb-connector-c \
         mongodb-tools \
         openssh-client \
         openssh-sftp-server \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -6,14 +6,12 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 
 ENV LAGOON=node
 
-RUN apk update \
+RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
     && apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
-        mariadb-client \
-        mariadb-connector-c \
         mongodb-tools \
         openssh-client \
         openssh-sftp-server \

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:18.20-alpine3.19
+FROM node:18.20-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:20.16-alpine3.19
+FROM node:20.16-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/node/22.Dockerfile
+++ b/images/node/22.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM node:22.6-alpine3.19
+FROM node:22.6-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -8,14 +8,12 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk update \
-    && apk add --no-cache git \
-        bash \
+RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk add --no-cache bash \
         coreutils \
         findutils \
+        git \
         gzip  \
-        mariadb-client \
-        mariadb-connector-c \
         mongodb-tools \
         nodejs=~20 \
         npm \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -8,14 +8,12 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk update \
-    && apk add --no-cache git \
-        bash \
+RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk add --no-cache bash \
         coreutils \
         findutils \
+        git \
         gzip  \
-        mariadb-client \
-        mariadb-connector-c \
         mongodb-tools \
         nodejs=~20 \
         npm \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -8,13 +8,12 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk add --no-cache git \
-        bash \
+RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk add --no-cache bash \
         coreutils \
         findutils \
+        git \
         gzip  \
-        mariadb-client \
-        mariadb-connector-c \
         mongodb-tools \
         nodejs=~20 \
         npm \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.1.29-fpm-alpine3.19
+FROM php:8.1.29-fpm-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
@@ -128,6 +128,7 @@ ENV NEWRELIC_VERSION=11.0.0.13
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
+    && mkdir /etc/conf.d && mkdir /etc/init.d \
     && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
     && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.2.22-fpm-alpine3.19
+FROM php:8.2.22-fpm-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
@@ -128,6 +128,7 @@ ENV NEWRELIC_VERSION=11.0.0.13
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
+    && mkdir /etc/conf.d && mkdir /etc/init.d \
     && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
     && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -5,7 +5,7 @@ FROM composer:latest as healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
-FROM php:8.3.10-fpm-alpine3.19
+FROM php:8.3.10-fpm-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
@@ -137,6 +137,7 @@ ENV NEWRELIC_VERSION=11.0.0.13
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \
+    && mkdir /etc/conf.d && mkdir /etc/init.d \
     && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 ./newrelic-install install \
     && sed -i -e "s/newrelic.appname = .*/newrelic.appname = \"\${LAGOON_PROJECT:-noproject}-\${LAGOON_GIT_SAFE_BRANCH:-nobranch}\"/" /usr/local/etc/php/conf.d/newrelic.ini \
     && sed -i -e "s/;newrelic.enabled = .*/newrelic.enabled = \${NEWRELIC_ENABLED:-false}/" /usr/local/etc/php/conf.d/newrelic.ini \

--- a/images/postgres/12.Dockerfile
+++ b/images/postgres/12.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM postgres:12.20-alpine3.19
+FROM postgres:12.20-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres/13.Dockerfile
+++ b/images/postgres/13.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM postgres:13.16-alpine3.19
+FROM postgres:13.16-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres/14.Dockerfile
+++ b/images/postgres/14.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM postgres:14.13-alpine3.19
+FROM postgres:14.13-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres/15.Dockerfile
+++ b/images/postgres/15.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM postgres:15.8-alpine3.19
+FROM postgres:15.8-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/postgres/16.Dockerfile
+++ b/images/postgres/16.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM postgres:16.4-alpine3.19
+FROM postgres:16.4-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.10.Dockerfile
+++ b/images/python/3.10.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.10.14-alpine3.19
+FROM python:3.10.14-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.11.Dockerfile
+++ b/images/python/3.11.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.11.9-alpine3.19
+FROM python:3.11.9-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.12.Dockerfile
+++ b/images/python/3.12.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.12.3-alpine3.18
+FROM python:3.12.4-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.8.19-alpine3.19
+FROM python:3.8.19-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/python/3.9.Dockerfile
+++ b/images/python/3.9.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM python:3.9.19-alpine3.19
+FROM python:3.9.19-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/redis/6.Dockerfile
+++ b/images/redis/6.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM redis:6.2.14-alpine3.19
+FROM redis:6.2.14-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/redis/7.Dockerfile
+++ b/images/redis/7.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM redis:7.2.5-alpine3.19
+FROM redis:7.2.5-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/ruby/3.1.Dockerfile
+++ b/images/ruby/3.1.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM ruby:3.1.6-alpine3.19
+FROM ruby:3.1.6-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/ruby/3.2.Dockerfile
+++ b/images/ruby/3.2.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
 
-FROM ruby:3.2.5-alpine3.19
+FROM ruby:3.2.5-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"

--- a/images/ruby/3.3.Dockerfile
+++ b/images/ruby/3.3.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons as commons
-FROM ruby:3.3.4-alpine3.19
+FROM ruby:3.3.4-alpine3.20
 
 LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"


### PR DESCRIPTION
This PR updates all images to the latest Alpine release - https://alpinelinux.org/posts/Alpine-3.20.0-released.html

However, the version of the mariadb-client in 3.20 introduced a [backwards incompatible update](https://mariadb.org/mariadb-dump-file-compatibility-change/) to the mariadbdump command. To mitigate this, I have pinned the mariadb-client package in the cli images to a version that is known to work with all versions of mariadb whilst we work out how best to implement the update.