### PR TITLE
Add more labels to Lagoon images

### DIFF
--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 x-user:
   &default-user
     # The default user under which the containers should run. Change this if you are on linux and run with another user than id `1000`

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 x-user:
   &default-user
     # The default user under which the containers should run. Change this if you are on linux and run with another user than id `1000`

--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -3,13 +3,21 @@ FROM amazeeio/envplate:v1.0.3 AS envplate
 
 FROM alpine:3.20.2
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/commons/Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Base image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/commons"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.20"
 
 ENV LAGOON=commons
 
 COPY lagoon/ /lagoon/
-RUN mkdir -p /lagoon/bin
+RUN mkdir -p /lagoon/bin \
+    && echo $LAGOON_VERSION > /lagoon/version
 COPY fix-permissions fix-dir-permissions docker-sleep entrypoint-readiness wait-for /bin/
 COPY .bashrc /home/.bashrc
 
@@ -27,10 +35,6 @@ RUN apk update \
     && ln -s /home/.bashrc /home/.profile
 
 RUN fix-permissions /etc/passwd
-
-ARG LAGOON_VERSION
-RUN echo $LAGOON_VERSION > /lagoon/version
-ENV LAGOON_VERSION=$LAGOON_VERSION
 
 ENV TMPDIR=/tmp \
     TMP=/tmp \

--- a/images/mariadb-drupal/10.11.Dockerfile
+++ b/images/mariadb-drupal/10.11.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/mariadb-10.11
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb-drupal/10.11.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.11 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.11-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/mariadb-10.11"
 
 ENV MARIADB_DATABASE=drupal \
     MARIADB_USER=drupal \

--- a/images/mariadb-drupal/10.4.Dockerfile
+++ b/images/mariadb-drupal/10.4.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/mariadb-10.4
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb-drupal/10.4.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.4 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.4-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/mariadb-10.4"
 
 ENV MARIADB_DATABASE=drupal \
     MARIADB_USER=drupal \

--- a/images/mariadb-drupal/10.5.Dockerfile
+++ b/images/mariadb-drupal/10.5.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/mariadb-10.5
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb-drupal/10.5.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.5 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.5-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/mariadb-10.5"
 
 ENV MARIADB_DATABASE=drupal \
     MARIADB_USER=drupal \

--- a/images/mariadb-drupal/10.6.Dockerfile
+++ b/images/mariadb-drupal/10.6.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/mariadb-10.6
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb-drupal/10.6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.6 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.6-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/mariadb-10.6"
 
 ENV MARIADB_DATABASE=drupal \
     MARIADB_USER=drupal \

--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM alpine:3.19.3
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.11.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.11 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.11"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.19"
+
+ENV LAGOON=mariadb
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -1,13 +1,19 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 # Held at 3.12.x to ensure mariadb 10.4 whilst we evaluate upgrade path
 FROM alpine:3.12.12
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.4.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.4 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.4"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.12"
+
+ENV LAGOON=mariadb
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -1,13 +1,19 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 # Held at 3.14.x to ensure mariadb 10.5 whilst we evaluate upgrade path
 FROM alpine:3.14.10
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.5.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.5 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.5"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.14"
+
+ENV LAGOON=mariadb
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/mariadb/10.6.Dockerfile
+++ b/images/mariadb/10.6.Dockerfile
@@ -1,13 +1,19 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 # Held at 3.17.x to ensure mariadb 10.6 whilst we evaluate upgrade path
 FROM alpine:3.17.9
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MariaDB 10.6 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-10.6"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.17"
+
+ENV LAGOON=mariadb
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/mongo/4.Dockerfile
+++ b/images/mongo/4.Dockerfile
@@ -1,17 +1,21 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM alpine:3.20.2
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=mongo
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mongo/4.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MongoDB 4 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mongo-4"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.20"
+
+ENV LAGOON=mongo
 
 COPY --from=commons /lagoon /lagoon
-COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 COPY --from=commons /sbin/tini /sbin/
 COPY --from=commons /home /home
 

--- a/images/mysql/8.0.Dockerfile
+++ b/images/mysql/8.0.Dockerfile
@@ -1,12 +1,19 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM mysql:8.0.39-oracle
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mysql/8.0.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MySQL 8.0 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mysql-8.0"
+LABEL org.opencontainers.image.base.name="docker.io/mysql:8.0-oracle"
+
+ENV LAGOON=mysql
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -61,7 +68,7 @@ RUN touch /var/log/mariadb-slow.log && /bin/fix-permissions /var/log/mariadb-slo
 # change the user of the Docker Image to this user.
 RUN usermod -a -G root mysql
 USER mysql
-ENV USER_NAME mysql
+ENV USER_NAME=mysql
 
 WORKDIR /var/lib/mysql
 EXPOSE 3306

--- a/images/mysql/8.4.Dockerfile
+++ b/images/mysql/8.4.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM mysql:8.4.2-oracle
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mysql/8.4.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="MySQL 8.4 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mysql-8.4"
+LABEL org.opencontainers.image.base.name="docker.io/mysql:8.4-oracle"
+
+ENV LAGOON=mysql
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -61,7 +67,7 @@ RUN touch /var/log/mariadb-slow.log && /bin/fix-permissions /var/log/mariadb-slo
 # change the user of the Docker Image to this user.
 RUN usermod -a -G root mysql
 USER mysql
-ENV USER_NAME mysql
+ENV USER_NAME=mysql
 
 WORKDIR /var/lib/mysql
 EXPOSE 3306

--- a/images/nginx-drupal/Dockerfile
+++ b/images/nginx-drupal/Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/nginx
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=nginx
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/nginx-drupal/Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="OpenResty (Nginx) image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/nginx-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/nginx"
 
 RUN mkdir -p /etc/nginx/conf.d/drupal
 

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,14 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM openresty/openresty:1.25.3.2-0-alpine
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=nginx
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/nginx/Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="OpenResty (Nginx) image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/nginx"
+LABEL org.opencontainers.image.base.name="docker.io/openresty/openresty:1.25-alpine"
+
+ENV LAGOON=nginx
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/node-builder/18.Dockerfile
+++ b/images/node-builder/18.Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/node-18
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-builder/18.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 18 builder image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-18-builder"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-18"
 
 RUN apk update \
     && apk add --no-cache \

--- a/images/node-builder/20.Dockerfile
+++ b/images/node-builder/20.Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/node-20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-builder/20.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 20 builder image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-20-builder"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-20"
 
 RUN apk update \
     && apk add --no-cache \

--- a/images/node-builder/22.Dockerfile
+++ b/images/node-builder/22.Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/node-22
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-builder/22.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 22 builder image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-22-builder"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-22"
 
 RUN apk update \
     && apk add --no-cache \

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/node-18
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-cli/18.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 18 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-18-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-18"
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
     && apk add --no-cache bash \

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/node-20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-cli/20.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 20 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-20-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-20"
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
     && apk add --no-cache bash \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -1,10 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/node-22
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-cli/22.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 22 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-22-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-22"
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
     && apk add --no-cache bash \

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -1,14 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM node:18.20-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/18.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 18 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-18"
+LABEL org.opencontainers.image.base.name="docker.io/node:18-alpine3.20"
+
+ENV LAGOON=node
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -1,14 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM node:20.16-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/20.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 20 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-20"
+LABEL org.opencontainers.image.base.name="docker.io/node:20-alpine3.20"
+
+ENV LAGOON=node
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/node/22.Dockerfile
+++ b/images/node/22.Dockerfile
@@ -1,14 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM node:22.6-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=node
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/22.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 22 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-22"
+LABEL org.opencontainers.image.base.name="docker.io/node:22-alpine3.20"
+
+ENV LAGOON=node
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/opensearch/2.Dockerfile
+++ b/images/opensearch/2.Dockerfile
@@ -1,14 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM opensearchproject/opensearch:2.16.0
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=opensearch
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/opensearch/2.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="OpenSearch 2 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/opensearch-2"
+LABEL org.opencontainers.image.base.name="docker.io/opensearchproject/opensearch:2"
+
+ENV LAGOON=opensearch
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/php-cli-drupal/8.1.Dockerfile
+++ b/images/php-cli-drupal/8.1.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/php-8.1-cli
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli-drupal/8.1.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.1 cli image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.1-cli-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/php-8.1-cli"
 
 ENV LAGOON=cli-drupal
 

--- a/images/php-cli-drupal/8.2.Dockerfile
+++ b/images/php-cli-drupal/8.2.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/php-8.2-cli
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli-drupal/8.2.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.2 cli image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.2-cli-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/php-8.2-cli"
 
 ENV LAGOON=cli-drupal
 

--- a/images/php-cli-drupal/8.3.Dockerfile
+++ b/images/php-cli-drupal/8.3.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/php-8.3-cli
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli-drupal/8.3.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.3 cli image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.3-cli-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/php-8.3-cli"
 
 ENV LAGOON=cli-drupal
 

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/php-8.1-fpm
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.1.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.1 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.1-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/php-8.1-fpm"
 
 ENV LAGOON=cli
 

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/php-8.2-fpm
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.2.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.2 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.2-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/php-8.2-fpm"
 
 ENV LAGOON=cli
 

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/php-8.3-fpm
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.3.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.3 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.3-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/php-8.3-fpm"
 
 ENV LAGOON=cli
 

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -1,19 +1,23 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
-FROM composer:latest as healthcheckbuilder
+FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
 FROM php:8.1.29-fpm-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=php
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.1.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.1 FPM image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.1-fpm"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.1-fpm-alpine3.20"
+
+ENV LAGOON=php
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -1,19 +1,23 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
-FROM composer:latest as healthcheckbuilder
+FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
 FROM php:8.2.22-fpm-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=php
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.2.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.2 FPM image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.2-fpm"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.2-fpm-alpine3.20"
+
+ENV LAGOON=php
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -1,19 +1,23 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
-FROM composer:latest as healthcheckbuilder
+FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.6
 
 FROM php:8.3.10-fpm-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=php
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.3.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PHP 8.3 FPM image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/php-8.3-fpm"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.3-fpm-alpine3.20"
+
+ENV LAGOON=php
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/php-fpm/README.md
+++ b/images/php-fpm/README.md
@@ -1,1 +1,1 @@
-Please reference the [Lagoon Docs](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/php-fpm/)
+Please reference the [Lagoon Docs](https://docs.lagoon.sh/docker-images/php-fpm/)

--- a/images/postgres-ckan/11.Dockerfile
+++ b/images/postgres-ckan/11.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-11
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-ckan/11.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 11 image optimised for CKAN workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-11-ckan"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-11"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres-drupal/11.Dockerfile
+++ b/images/postgres-drupal/11.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-11
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/11.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 11 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-11-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-11"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres-drupal/12.Dockerfile
+++ b/images/postgres-drupal/12.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-12
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/12.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 12 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-12-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-12"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres-drupal/13.Dockerfile
+++ b/images/postgres-drupal/13.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-13
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/13.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 13 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-13-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-13"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres-drupal/14.Dockerfile
+++ b/images/postgres-drupal/14.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-14
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/14.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 14 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-14-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-14"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres-drupal/15.Dockerfile
+++ b/images/postgres-drupal/15.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-15
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/15.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 15 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-15-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-15"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres-drupal/16.Dockerfile
+++ b/images/postgres-drupal/16.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/postgres-16
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/16.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 16 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-16-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-16"
 
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \

--- a/images/postgres/11.Dockerfile
+++ b/images/postgres/11.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM postgres:11.22-alpine3.19
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/11.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 11 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-11"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:11-alpine3.20"
+
+ENV LAGOON=postgres
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -30,8 +36,6 @@ RUN apk update \
 
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
-
-ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/
 

--- a/images/postgres/12.Dockerfile
+++ b/images/postgres/12.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM postgres:12.20-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/12.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 12 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-12"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:12-alpine3.20"
+
+ENV LAGOON=postgres
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -30,8 +36,6 @@ RUN apk update \
 
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
-
-ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/
 

--- a/images/postgres/13.Dockerfile
+++ b/images/postgres/13.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM postgres:13.16-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/13.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 13 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-13"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:13-alpine3.20"
+
+ENV LAGOON=postgres
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -30,8 +36,6 @@ RUN apk update \
 
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
-
-ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/
 

--- a/images/postgres/14.Dockerfile
+++ b/images/postgres/14.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM postgres:14.13-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/14.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 14 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-14"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:14-alpine3.20"
+
+ENV LAGOON=postgres
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -30,8 +36,6 @@ RUN apk update \
 
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
-
-ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/
 

--- a/images/postgres/15.Dockerfile
+++ b/images/postgres/15.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM postgres:15.8-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/15.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 15 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-15"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:15-alpine3.20"
+
+ENV LAGOON=postgres
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -30,8 +36,6 @@ RUN apk update \
 
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
-
-ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/
 

--- a/images/postgres/16.Dockerfile
+++ b/images/postgres/16.Dockerfile
@@ -1,12 +1,18 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM postgres:16.4-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/16.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="PostgreSQL 16 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-16"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:16-alpine3.20"
+
+ENV LAGOON=postgres
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
@@ -30,8 +36,6 @@ RUN apk update \
 
 RUN fix-permissions /etc/passwd \
     && mkdir -p /home
-
-ENV LAGOON=postgres
 
 COPY postgres-backup.sh /lagoon/
 

--- a/images/python/3.10.Dockerfile
+++ b/images/python/3.10.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM python:3.10.14-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.10.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Python 3.10 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/python-3.10"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.10-alpine3.20"
 
 ENV LAGOON=python
 

--- a/images/python/3.11.Dockerfile
+++ b/images/python/3.11.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM python:3.11.9-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.11.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Python 3.11 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/python-3.11"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.11-alpine3.20"
 
 ENV LAGOON=python
 

--- a/images/python/3.12.Dockerfile
+++ b/images/python/3.12.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM python:3.12.5-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.12.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Python 3.12 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/python-3.12"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.12-alpine3.20"
 
 ENV LAGOON=python
 

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM python:3.8.19-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.8.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Python 3.8 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/python-3.8"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.8-alpine3.20"
 
 ENV LAGOON=python
 

--- a/images/python/3.9.Dockerfile
+++ b/images/python/3.9.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM python:3.9.19-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.9.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Python 3.9 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/python-3.9"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.9-alpine3.20"
 
 ENV LAGOON=python
 

--- a/images/rabbitmq-cluster/Dockerfile
+++ b/images/rabbitmq-cluster/Dockerfile
@@ -1,6 +1,16 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/rabbitmq
 
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/rabbitmq-cluster/Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="RabbitMQ image optimised for clustered workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/rabbitmq-cluster"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/rabbitmq"
+
 RUN rabbitmq-plugins --offline enable rabbitmq_peer_discovery_k8s
 
 ADD enabled_plugins /etc/rabbitmq/enabled_plugins

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -1,16 +1,26 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM rabbitmq:3.10.25-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/rabbitmq/Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="RabbitMQ image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/rabbitmq"
+LABEL org.opencontainers.image.base.name="docker.io/rabbitmq:3-management-alpine"
+
+ENV LAGOON=rabbitmq
 
 ENV RABBITMQ_DEFAULT_USER='guest' \
     RABBITMQ_DEFAULT_PASS='guest'\
     RABBITMQ_DEFAULT_HA_PATTERN='^$'\
     RABBITMQ_DEFAULT_VHOST='/'
 
-COPY --from=commons /bin/ep /bin/fix-permissions /bin/
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 
 RUN wget -P /plugins https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.10.2/rabbitmq_delayed_message_exchange-3.10.2.ez \
     && chown rabbitmq:rabbitmq /plugins/rabbitmq_delayed_message_exchange-* \

--- a/images/redis-persistent/6.Dockerfile
+++ b/images/redis-persistent/6.Dockerfile
@@ -1,7 +1,14 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/redis-6
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Redis 6 image optimised for persistent workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/redis-6-persistent"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/redis-6"
 
 ENV FLAVOR=persistent

--- a/images/redis-persistent/7.Dockerfile
+++ b/images/redis-persistent/7.Dockerfile
@@ -1,7 +1,14 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/redis-7
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/7.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Redis 7 image optimised for persistent workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/redis-7-persistent"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/redis-7"
 
 ENV FLAVOR=persistent

--- a/images/redis/6.Dockerfile
+++ b/images/redis/6.Dockerfile
@@ -1,15 +1,20 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM redis:6.2.14-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=redis
-ENV FLAVOR=ephemeral
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Redis 6 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/redis-6"
+LABEL org.opencontainers.image.base.name="docker.io/redis:6-alpine3.20"
+
+ENV LAGOON=redis
+
+ENV FLAVOR=ephemeral
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/redis/7.Dockerfile
+++ b/images/redis/7.Dockerfile
@@ -1,15 +1,20 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM redis:7.2.5-alpine3.20
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=redis
-ENV FLAVOR=ephemeral
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Redis 7 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/redis-7"
+LABEL org.opencontainers.image.base.name="docker.io/redis:7-alpine3.20"
+
+ENV LAGOON=redis
+
+ENV FLAVOR=ephemeral
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon

--- a/images/ruby/3.1.Dockerfile
+++ b/images/ruby/3.1.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM ruby:3.1.6-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.1.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Ruby 3.1 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/ruby-3.1"
+LABEL org.opencontainers.image.base.name="docker.io/ruby:3.1-alpine3.20"
 
 ENV LAGOON=ruby
 

--- a/images/ruby/3.2.Dockerfile
+++ b/images/ruby/3.2.Dockerfile
@@ -1,10 +1,17 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM ruby:3.2.5-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.2.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Ruby 3.2 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/ruby-3.2"
+LABEL org.opencontainers.image.base.name="docker.io/ruby:3.2-alpine3.20"
 
 ENV LAGOON=ruby
 

--- a/images/ruby/3.3.Dockerfile
+++ b/images/ruby/3.3.Dockerfile
@@ -1,9 +1,16 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM ruby:3.3.4-alpine3.20
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.3.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Ruby 3.3 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/ruby-3.3"
+LABEL org.opencontainers.image.base.name="docker.io/ruby:3.3-alpine3.20"
 
 ENV LAGOON=ruby
 

--- a/images/solr-drupal/8.Dockerfile
+++ b/images/solr-drupal/8.Dockerfile
@@ -6,8 +6,15 @@ ADD https://git.drupalcode.org/project/search_api_solr.git#4.3.3 /search_api_sol
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/solr-8
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/solr-drupal/8.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Solr 8 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/solr-8-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/solr-8"
 
 COPY --from=jumpstart /search_api_solr/jump-start/solr8/config-set /solr-conf/conf
 ENV SOLR_INSTALL_DIR=/opt/solr

--- a/images/solr-drupal/9.Dockerfile
+++ b/images/solr-drupal/9.Dockerfile
@@ -1,13 +1,20 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as jumpstart
+FROM ${IMAGE_REPO:-lagoon}/commons AS jumpstart
 
 ADD https://git.drupalcode.org/project/search_api_solr.git#4.3.3 /search_api_solr
 
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/solr-9
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/solr-drupal/9.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Solr 9 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/solr-9-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/solr-9"
 
 COPY --from=jumpstart /search_api_solr/jump-start/solr9/config-set /solr-conf/conf
 ENV SOLR_INSTALL_DIR=/opt/solr

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -1,20 +1,25 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM solr:8.11.3-slim
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=solr
-ENV SOLR_DATA_HOME=/var/solr
-ENV SOLR_LOGS_DIR=/opt/solr/server/logs
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/solr/8.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Solr 8 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/solr-8"
+LABEL org.opencontainers.image.base.name="docker.io/solr:8"
+
+ENV LAGOON=solr
+
+ENV SOLR_DATA_HOME=/var/solr
+ENV SOLR_LOGS_DIR=/opt/solr/server/logs
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
-COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 COPY --from=commons /home/.bashrc /home/.bashrc
 
 ENV TMPDIR=/tmp \

--- a/images/solr/9.Dockerfile
+++ b/images/solr/9.Dockerfile
@@ -1,20 +1,25 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 FROM solr:9.6.1
-
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=solr
-ENV SOLR_DATA_HOME=/var/solr
-ENV SOLR_LOGS_DIR=/opt/solr/server/logs
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/solr/9.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Solr 9 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/solr-9"
+LABEL org.opencontainers.image.base.name="docker.io/solr:9"
+
+ENV LAGOON=solr
+
+ENV SOLR_DATA_HOME=/var/solr
+ENV SOLR_LOGS_DIR=/opt/solr/server/logs
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
-COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 COPY --from=commons /home/.bashrc /home/.bashrc
 
 ENV TMPDIR=/tmp \

--- a/images/varnish-drupal/6.Dockerfile
+++ b/images/varnish-drupal/6.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/varnish-6
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish-drupal/6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 6 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-6-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-6"
 
 USER root
 

--- a/images/varnish-drupal/7.Dockerfile
+++ b/images/varnish-drupal/7.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/varnish-7
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish-drupal/7.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 7 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-7-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-7"
 
 USER root
 

--- a/images/varnish-persistent-drupal/6.Dockerfile
+++ b/images/varnish-persistent-drupal/6.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/varnish-6-drupal
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish-persistent-drupal/6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 6 image optimised for persistent Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-6-persistent-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-6-drupal"
 
 VOLUME /var/cache/varnish
 

--- a/images/varnish-persistent-drupal/7.Dockerfile
+++ b/images/varnish-persistent-drupal/7.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/varnish-7-drupal
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish-persistent-drupal/7.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 7 image optimised for persistent Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-7-persistent-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-7-drupal"
 
 VOLUME /var/cache/varnish
 

--- a/images/varnish-persistent/6.Dockerfile
+++ b/images/varnish-persistent/6.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/varnish-6
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish-persistent/6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 6 image optimised for persistent workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-6-persistent"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-6"
 
 VOLUME /var/cache/varnish
 

--- a/images/varnish-persistent/7.Dockerfile
+++ b/images/varnish-persistent/7.Dockerfile
@@ -1,8 +1,15 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/varnish-7
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish-persistent/7.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 7 image optimised for persistent workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-7-persistent"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-7"
 
 VOLUME /var/cache/varnish
 

--- a/images/varnish/6.Dockerfile
+++ b/images/varnish/6.Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
-FROM varnish:6.0.13 as vmod
+FROM varnish:6.0.13 AS vmod
 
 USER root
 RUN apt-get update \
@@ -33,17 +33,21 @@ RUN cd /tmp && curl -sSLO https://github.com/varnish/varnish-modules/archive/${V
 
 FROM varnish:6.0.13
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish/6.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 6 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-6"
+LABEL org.opencontainers.image.base.name="docker.io/varnish:6.0"
 
 ENV LAGOON=varnish
 
-ARG LAGOON_VERSION
-ENV LAGOON_VERSION=$LAGOON_VERSION
-
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
-COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 COPY --from=commons /home /home
 
 ENV TMPDIR=/tmp \

--- a/images/varnish/7.Dockerfile
+++ b/images/varnish/7.Dockerfile
@@ -1,15 +1,19 @@
 ARG IMAGE_REPO
-FROM ${IMAGE_REPO:-lagoon}/commons as commons
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
 
 FROM varnish:7.5-alpine
 
-LABEL org.opencontainers.image.authors="The Lagoon Authors" maintainer="The Lagoon Authors"
-LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images" repository="https://github.com/uselagoon/lagoon-images"
-
-ENV LAGOON=varnish
-
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish/7.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Varnish 7 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/varnish-7"
+LABEL org.opencontainers.image.base.name="docker.io/varnish:7-alpine"
+
+ENV LAGOON=varnish
 
 # Copy commons files
 COPY --from=commons /lagoon /lagoon


### PR DESCRIPTION
This PR adds a fuller suite of docker labels to the Lagoon Images

e.g.
```
org.opencontainers.image.authors="The Lagoon Authors"
org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/varnish/7.Dockerfile"
org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
org.opencontainers.image.version="${LAGOON_VERSION}"
org.opencontainers.image.description="Varnish 7 image optimised for running in Lagoon in production and locally"
org.opencontainers.image.title="uselagoon/varnish-7"
org.opencontainers.image.base.name="docker.io/varnish:7-alpine"
```