### PR TITLE
Adds a custom 404 handler, common for static rendered HTML sites

### DIFF
--- a/images/nginx/helpers/400_custom-404.conf
+++ b/images/nginx/helpers/400_custom-404.conf
@@ -1,0 +1,1 @@
+error_page 404 /404.html;


### PR DESCRIPTION
Having a custom 404 helper would be a convenient config file to have in the base image. I thought this might be helpful to others.

Nuxt and other static site generators render a custom 404 to /404.html by default. If the 404.html file is not found, Nginx still renders its standard boring openresty 404 so there seems to be no harm in having the default there and avoiding needing to copy it into the app's nginx dockerfile.

Thoughts?