### PR TITLE
Feat: Add support for host.docker.internal for SSMTP.

### DIFF
--- a/images/php-fpm/entrypoints/50-ssmtp.sh
+++ b/images/php-fpm/entrypoints/50-ssmtp.sh
@@ -23,6 +23,10 @@ if [ ${SSMTP_MAILHUB+x} ]; then
 elif nc -z -w 1 172.17.0.1 1025 &> /dev/null; then
   echo -e "\nmailhub=172.17.0.1:1025" >> /etc/ssmtp/ssmtp.conf
   return
+# check if we find mailhog on the internal docker host
+elif nc -z -w 1 host.docker.internal 1025 &> /dev/null; then
+  echo -e "\nmailhub=host.docker.internal:1025" >> /etc/ssmtp/ssmtp.conf
+  return
 # Fallback: check if on Lagoon then assume mxout.lagoon.svc can do smtp TLS
 elif [ ! -z ${LAGOON_PROJECT} ]; then
   echo -e "UseTLS=Yes\nmailhub=mxout.lagoon.svc:465" >> /etc/ssmtp/ssmtp.conf


### PR DESCRIPTION
The generated `ssmtp.conf` file from the entrypoint can now determine if `host.docker.internal` has a valid mailhog instance running.
```
php:/app$ cat /etc/ssmtp/ssmtp.conf
# ssmtp config (will be filled during entrypoint 50-ssmtp.sh)

# Email 'From header's can override the default domain
FromLineOverride=yes

mailhub=host.docker.internal:1025

php:/app$ nc -zv host.docker.internal 1025
host.docker.internal (192.168.65.254:1025) open

php:/app$ sendmail -v  test@test.com < /tmp/mail.txt
[<-] 220 mailhog.example ESMTP MailHog
[->] HELO 7ab411118f33
[<-] 250 Hello 7ab411118f33
[->] MAIL FROM:<user@7ab411118f33>
[<-] 250 Sender user@7ab411118f33 ok
[->] RCPT TO:<test@test.com>
[<-] 250 Recipient test@test.com ok
[->] DATA
[<-] 354 End data with <CR><LF>.<CR><LF>
[->] Received: by 7ab411118f33 (sSMTP sendmail emulation); Wed, 07 Aug 2024 02:46:20 +0000
[->] From: "user" <user@7ab411118f33>
[->] Date: Wed, 07 Aug 2024 02:46:20 +0000
[->] Subject: Test mail
[->]
[->] This is a test email.
[->] .
[<-] 250 Ok: queued as T2VBejKo481dBVqNYrtDN9dOAXyehxTCsySJ5SyyoxI=@mailhog.example
[->] QUIT
[<-] 221 Bye
```


![image](https://github.com/user-attachments/assets/544eef9d-077f-437b-9da4-a2e8d8a8c2eb)
