### PR TITLE
Testing/renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -216,6 +216,16 @@
       ]
     },
     {
+      "groupName": "Redis Images",
+      "allowedVersions": "<7.4.0",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "redis"
+      ]
+    },
+    {
       "groupName": "ELK Stack",
       "allowedVersions": "<7.11.0",
       "matchDatasources": [

--- a/renovate.json
+++ b/renovate.json
@@ -226,32 +226,6 @@
       ]
     },
     {
-      "groupName": "ELK Stack",
-      "allowedVersions": "<7.11.0",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "docker.elastic.co/elasticsearch/elasticsearch",
-        "docker.elastic.co/logstash/logstash",
-        "docker.elastic.co/kibana/kibana"
-      ]
-    },
-    {
-      "enabled": false,
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "matchPackageNames": [
-        "docker.elastic.co/elasticsearch/elasticsearch",
-        "docker.elastic.co/logstash/logstash",
-        "docker.elastic.co/kibana/kibana"
-      ]
-    },
-    {
       "enabled": false,
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
Updates renovate config to remove references to ELK stack, and to pin Redis images to <7.4.0 to avoid license change ambiguity (https://redis.io/blog/redis-adopts-dual-source-available-licensing/)