### PR TITLE
Ensure /sbin/tini exists

### DIFF
--- a/images/mysql/8.0.Dockerfile
+++ b/images/mysql/8.0.Dockerfile
@@ -18,6 +18,7 @@ ENV LAGOON=mysql
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
 COPY --from=commons /home /home
 
 RUN fix-permissions /etc/passwd \

--- a/images/mysql/8.4.Dockerfile
+++ b/images/mysql/8.4.Dockerfile
@@ -17,6 +17,7 @@ ENV LAGOON=mysql
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
 COPY --from=commons /home /home
 
 RUN fix-permissions /etc/passwd \


### PR DESCRIPTION
When using mysql image in lando, it fails hard (but unfortunately mostly silently)
lando logs:
```
mariadb_1  | lando 05:09:06.08 INFO  ==> Lando handing off to: /sbin/tini -- /lagoon/entrypoints.bash mysqld
mariadb_1  | /lando-entrypoint.sh: line 86: /sbin/tini: No such file or directory
```
![image](https://github.com/user-attachments/assets/a40d1c2e-9a67-40dd-a982-03d609100c8f)
which causes the mysqld server to never start.

This appears to be caused because some shared files expect tini in /sbin/ but in this image it is by default at /usr/bin/