### PR TITLE
Replace upstream tini with krallin/tini in MySQL image

### DIFF
--- a/images/mysql/8.0.Dockerfile
+++ b/images/mysql/8.0.Dockerfile
@@ -44,10 +44,12 @@ RUN microdnf install -y epel-release \
         gettext \
         net-tools \
         pwgen \
-        tini \
         wget; \
     rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
     curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+
+RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini
 
 COPY entrypoints/ /lagoon/entrypoints/
 COPY mysql-backup.sh /lagoon/
@@ -73,5 +75,5 @@ ENV USER_NAME=mysql
 WORKDIR /var/lib/mysql
 EXPOSE 3306
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/lagoon/entrypoints.bash"]
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
 CMD ["mysqld"]

--- a/images/mysql/8.4.Dockerfile
+++ b/images/mysql/8.4.Dockerfile
@@ -43,10 +43,12 @@ RUN microdnf install -y epel-release \
         gettext \
         net-tools \
         pwgen \
-        tini \
         wget; \
     rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
     curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+
+RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini
 
 COPY entrypoints/ /lagoon/entrypoints/
 COPY mysql-backup.sh /lagoon/
@@ -72,5 +74,5 @@ ENV USER_NAME=mysql
 WORKDIR /var/lib/mysql
 EXPOSE 3306
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/lagoon/entrypoints.bash"]
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
 CMD ["mysqld"]


### PR DESCRIPTION
This PR uses the /sbin/tini provided by krallin/tini instead of the native oraclelinux tini to remain consistent with all the other images.

closes #1127 