### PR TITLE
Deprecate Postgres 11 image

### DIFF
--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -28,7 +28,6 @@ docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp:/
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-11:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mysql-8-0:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mysql-8-4:3306 -timeout 1m
-docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-11:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-12:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-13:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-14:5432 -timeout 1m
@@ -59,7 +58,6 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mysql-8-0
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mysql-8-4
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mongo-4
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-11
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-12
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-13
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-14
@@ -253,21 +251,6 @@ docker compose exec -T mysql-8-4  sh -c "mysql -D lagoon -u lagoon --password=la
 # mysql-8-4  should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb?service=mysql-8-4" | grep "SERVICE_HOST=8.4"
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb?service=mysql-8-4" | grep "LAGOON_TEST_VAR=all-images"
-
-# postgres-11 should be version 11 client
-docker compose exec -T postgres-11 bash -c "psql --version" | grep "psql" | grep "11."
-
-# postgres-11 should be version 11 server
-docker compose exec -T postgres-11 bash -c "echo U0VMRUNUIHZlcnNpb24oKTs= | base64 -d > /tmp/selectversion.sql"
-docker compose exec -T postgres-11 bash -c "psql -U lagoon -d lagoon < /tmp/selectversion.sql" | grep "PostgreSQL" | grep "11."
-
-# postgres-11 should have lagoon database
-docker compose exec -T postgres-11 bash -c "echo XGwrIGxhZ29vbg== | base64 -d > /tmp/listlagoon.sql"
-docker compose exec -T postgres-11 bash -c "psql -U lagoon -d lagoon < /tmp/listlagoon.sql" | grep "lagoon"
-
-# postgres-11 should be able to read/write data
-docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres?service=postgres-11" | grep "SERVICE_HOST=PostgreSQL 11"
-docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres?service=postgres-11" | grep "LAGOON_TEST_VAR=all-images"
 
 # postgres-12 should be version 12 client
 docker compose exec -T postgres-12 bash -c "psql --version" | grep "psql" | grep "12."

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -56,12 +56,6 @@ services:
       - "3306"
     << : *default-user # uses the defined user from top
 
-  postgres-11:
-    image: uselagoon/postgres-11:latest
-    ports:
-      - "5432"
-    << : *default-user # uses the defined user from top
-
   postgres-12:
     image: uselagoon/postgres-12:latest
     ports:

--- a/images/postgres-ckan/11.Dockerfile
+++ b/images/postgres-ckan/11.Dockerfile
@@ -11,6 +11,8 @@ LABEL org.opencontainers.image.description="PostgreSQL 11 image optimised for CK
 LABEL org.opencontainers.image.title="uselagoon/postgres-11-ckan"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-11"
 
+LABEL sh.lagoon.image.deprecated.status="discontinued"
+
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \
     && sed -i "s/#log_min_messages = warning/log_min_messages = log/" /usr/local/share/postgresql/postgresql.conf.sample

--- a/images/postgres-drupal/11.Dockerfile
+++ b/images/postgres-drupal/11.Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.description="PostgreSQL 11 image optimised for Dr
 LABEL org.opencontainers.image.title="uselagoon/postgres-11-drupal"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-11"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/postgres-16-drupal"
+
 # change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`) 
 RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \
     && sed -i "s/#log_min_messages = warning/log_min_messages = log/" /usr/local/share/postgresql/postgresql.conf.sample

--- a/images/postgres/11.Dockerfile
+++ b/images/postgres/11.Dockerfile
@@ -10,7 +10,10 @@ LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
 LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
 LABEL org.opencontainers.image.description="PostgreSQL 11 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/postgres-11"
-LABEL org.opencontainers.image.base.name="docker.io/postgres:11-alpine3.20"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:11-alpine3.19"
+
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/postgres-16"
 
 ENV LAGOON=postgres
 


### PR DESCRIPTION
PostgreSQL 11 has been out of support since November 2023

This final image adds the necessary LABELs to show it as deprecated to Lagoon, before it is removed next month.