### PR TITLE
build: deprecate python-3.8

### DIFF
--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -44,7 +44,6 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-prod
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-3-dev
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-3-prod
-docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-9
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-10
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep python-3-11
@@ -182,17 +181,6 @@ docker compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep 
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "session.cookie_samesite" | grep "Strict"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "upload_max_filesize" | grep "1024M"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-prod:9000" | grep "error_reporting" | grep "22519"
-
-# python-3-8 should be version 3.8
-docker compose exec -T python-3-8 sh -c "python -V" | grep "3.8"
-
-# python-3-8 should have basic tools installed
-docker compose exec -T python-3-8 sh -c "pip list --no-cache-dir" | grep "pip"
-docker compose exec -T python-3-8 sh -c "pip list --no-cache-dir" | grep "setuptools"
-docker compose exec -T python-3-8 sh -c "pip list --no-cache-dir" | grep "virtualenv" | grep "16.7.10"
-
-# python-3-8 should be serving content
-docker compose exec -T commons sh -c "curl python-3-8:3000/tmp/test" | grep "Python 3.8"
 
 # python-3-9 should be version 3.9
 docker compose exec -T python-3-9 sh -c "python -V" | grep "3.9"

--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -140,16 +140,6 @@ services:
         exec php -S 0.0.0.0:9000
         "] # runs a webserver with phpinfo output
 
-  python-3-8:
-    image: uselagoon/python-3.8:latest
-    ports:
-      - "3000"
-    << : *default-user # uses the defined user from top
-    command: ["sh", "-c", "
-        python -V | xargs > tmp/test;
-        exec python -m http.server 3000
-        "]
-
   python-3-9:
     image: uselagoon/python-3.9:latest
     ports:

--- a/images/python/3.8.Dockerfile
+++ b/images/python/3.8.Dockerfile
@@ -13,6 +13,9 @@ LABEL org.opencontainers.image.description="Python 3.8 image optimised for runni
 LABEL org.opencontainers.image.title="uselagoon/python-3.8"
 LABEL org.opencontainers.image.base.name="docker.io/python:3.8-alpine3.20"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/python-3.12"
+
 ENV LAGOON=python
 
 # Copy commons files


### PR DESCRIPTION
Python 3.8 went EOL in October 2024.

This PR introduces the deprecation LABEL prior to image removal next month.