### PR TITLE
chore: use php-extension-installer for pecls

### DIFF
--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -148,7 +148,7 @@ docker compose exec -T php-8-3-dev bash -c "php -i" | grep "PHP Version" | grep 
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "APCu Support" | grep "Enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "LibYAML Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "Redis Support" | grep "enabled"
-# TODO  docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "imagick module" | grep "enabled"
+docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "imagick module" | grep "enabled"
 
 # PHP 8.3 development should have default configuration.
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "memory_limit" | grep "400M"

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -47,6 +47,7 @@ COPY 00-lagoon-php.ini.tpl "$PHP_INI_DIR/conf.d/"
 COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
+COPY --from=docker.io/mlocati/php-extension-installer:2.6.4 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
     && apk add --no-cache --virtual .devdeps \
@@ -77,16 +78,11 @@ RUN apk update \
         postgresql-dev \
         # for yaml
         yaml-dev \
-    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
-    && yes '' | pecl install -f apcu-5.1.24 \
-    && yes '' | pecl install -f imagick-3.7.0 \
-    && yes '' | pecl install -f redis-6.1.0 \
-    && yes '' | pecl install -f xdebug-3.4.0 \
-    && yes '' | pecl install -f yaml-2.2.4 \
-    && docker-php-ext-enable apcu imagick redis xdebug yaml \
-    && rm -rf /tmp/pear \
-    && apk del -r \
-        .phpize-deps \
+    && install-php-extensions apcu-5.1.24 \
+    && install-php-extensions imagick-3.7.0 \
+    && install-php-extensions redis-6.1.0 \
+    && install-php-extensions xdebug-3.4.0 \
+    && install-php-extensions yaml-2.2.4 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -47,6 +47,7 @@ COPY 00-lagoon-php.ini.tpl "$PHP_INI_DIR/conf.d/"
 COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
+COPY --from=docker.io/mlocati/php-extension-installer:2.6.4 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
     && apk add --no-cache --virtual .devdeps \
@@ -77,16 +78,11 @@ RUN apk update \
         postgresql-dev \
         # for yaml
         yaml-dev \
-    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
-    && yes '' | pecl install -f apcu-5.1.24 \
-    && yes '' | pecl install -f imagick-3.7.0 \
-    && yes '' | pecl install -f redis-6.1.0 \
-    && yes '' | pecl install -f xdebug-3.4.0 \
-    && yes '' | pecl install -f yaml-2.2.4 \
-    && docker-php-ext-enable apcu imagick redis xdebug yaml \
-    && rm -rf /tmp/pear \
-    && apk del -r \
-        .phpize-deps \
+    && install-php-extensions apcu-5.1.24 \
+    && install-php-extensions imagick-3.7.0 \
+    && install-php-extensions redis-6.1.0 \
+    && install-php-extensions xdebug-3.4.0 \
+    && install-php-extensions yaml-2.2.4 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -47,6 +47,7 @@ COPY 00-lagoon-php.ini.tpl "$PHP_INI_DIR/conf.d/"
 COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
+COPY --from=docker.io/mlocati/php-extension-installer:2.6.4 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
     && apk add --no-cache --virtual .devdeps \
@@ -77,25 +78,11 @@ RUN apk update \
         postgresql-dev \
         # for yaml
         yaml-dev \
-    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
-    && yes '' | pecl install -f apcu-5.1.24 \
-    # && yes '' | pecl install -f imagick-3.7.0 \ # fix for https://github.com/Imagick/imagick/pull/641
-    && yes '' | pecl install -f redis-6.1.0 \
-    && yes '' | pecl install -f xdebug-3.4.0 \
-    && yes '' | pecl install -f yaml-2.2.4 \
-    # fix for https://github.com/Imagick/imagick/pull/641
-    && cd /tmp \
-    && yes '' | pecl download -Z imagick-3.7.0 \
-    && tar -xf imagick-3.7.0.tar imagick-3.7.0/Imagick.stub.php \
-    && sed -i '$ i\#endif' imagick-3.7.0/Imagick.stub.php \
-    && tar -uvf imagick-3.7.0.tar imagick-3.7.0/Imagick.stub.php \
-    && yes '' | pecl install -f /tmp/imagick-3.7.0.tar \
-    && docker-php-ext-enable apcu imagick redis xdebug yaml \
-    && rm -rf /tmp/imagick* \
-    && rm -rf /tmp/pear \
-    && cd - \
-    && apk del -r \
-        .phpize-deps \
+    && install-php-extensions apcu-5.1.24 \
+    && install-php-extensions https://codeload.github.com/amazeeio/imagick/tar.gz/refs/heads/php84 \
+    && install-php-extensions redis-6.1.0 \
+    && install-php-extensions xdebug-3.4.0 \
+    && install-php-extensions yaml-2.2.4 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,8 @@
         "(^|/|\\.)Dockerfile$"
       ],
       "matchStrings": [
-        "pecl install -f apcu-(?<currentValue>.*?) "
+        "pecl install -f apcu-(?<currentValue>.*?) ",
+        "install-php-extensions apcu-(?<currentValue>.*?) "
       ],
       "depNameTemplate": "krakjoe/apcu",
       "datasourceTemplate": "github-releases"
@@ -35,7 +36,8 @@
         "(^|/|\\.)Dockerfile$"
       ],
       "matchStrings": [
-        "pecl install -f imagick-(?<currentValue>.*?) "
+        "pecl install -f imagick-(?<currentValue>.*?) ",
+        "install-php-extensions imagick-(?<currentValue>.*?) "
       ],
       "depNameTemplate": "Imagick/imagick",
       "datasourceTemplate": "github-tags"
@@ -46,7 +48,8 @@
         "(^|/|\\.)Dockerfile$"
       ],
       "matchStrings": [
-        "pecl install -f redis-(?<currentValue>.*?) "
+        "pecl install -f redis-(?<currentValue>.*?) ",
+        "install-php-extensions redis-(?<currentValue>.*?) "
       ],
       "depNameTemplate": "phpredis/phpredis",
       "datasourceTemplate": "github-tags"
@@ -57,7 +60,8 @@
         "(^|/|\\.)Dockerfile$"
       ],
       "matchStrings": [
-        "pecl install -f xdebug-(?<currentValue>.*?) "
+        "pecl install -f xdebug-(?<currentValue>.*?) ",
+        "install-php-extensions xdebug-(?<currentValue>.*?) "
       ],
       "depNameTemplate": "xdebug/xdebug",
       "datasourceTemplate": "github-tags"
@@ -68,7 +72,8 @@
         "(^|/|\\.)Dockerfile$"
       ],
       "matchStrings": [
-        "pecl install -f yaml-(?<currentValue>.*?) "
+        "pecl install -f yaml-(?<currentValue>.*?) ",
+        "install-php-extensions yaml-(?<currentValue>.*?) "
       ],
       "depNameTemplate": "php/pecl-file_formats-yaml",
       "datasourceTemplate": "github-tags"


### PR DESCRIPTION
We've been seeing build failures on arm architecture with the current pecl install process - this PR switches to using the commonly-used mlocati version - which also allows installing from source - which we need for PHP8.3 and 8.4 support in ImageMagick