### PR TITLE
fix: local socket in mysql images

### DIFF
--- a/images/mariadb/entrypoints/9999-mariadb-init.bash
+++ b/images/mariadb/entrypoints/9999-mariadb-init.bash
@@ -149,6 +149,7 @@ EOF
   fi
 
   echo "done, now starting daemon"
+  touch /tmp/startup-init-complete
   touch /tmp/mariadb-init-complete
 
 fi

--- a/images/mysql/entrypoints/9999-mysql-init.bash
+++ b/images/mysql/entrypoints/9999-mysql-init.bash
@@ -126,8 +126,11 @@ EOF
     echo "[client]" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
     echo "user=root" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
     echo "password=${MYSQL_ROOT_PASSWORD}"  >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
+    echo "socket=/run/mysqld/mysqld.sock" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
     echo "[mysql]" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
     echo "database=${MYSQL_DATABASE}" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
+    echo "[mysqld]" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
+    echo "socket=/run/mysqld/mysqld.sock" >> ${MYSQL_DATA_DIR:-/var/lib/mysql}/.my.cnf
 
     for f in /docker-entrypoint-initdb.d/*; do
       if [ -e "$f" ]; then
@@ -147,6 +150,7 @@ EOF
   fi
 
   echo "done, now starting daemon"
+  touch /tmp/startup-init-complete
   touch /tmp/mysql-init-complete
 
 fi


### PR DESCRIPTION
The readiness probe in the mysql image fails when calling `/usr/share/container-scripts/mysql/readiness-probe.sh` due to no local socket defined.

This sets the socket in the mysql image so that is available to the readiness probes.

Additionally, this adds another init file in both the mysql and mariadb images that doesn't contain the vendor name.