### PR TITLE
build: add rsync & tar to missing images

### DIFF
--- a/images/mongo/4.Dockerfile
+++ b/images/mongo/4.Dockerfile
@@ -33,6 +33,8 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repos
 RUN apk update \
     && apk add --no-cache \
         mongodb=4.0.5-r0 \
+        rsync \
+        tar \
     && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /data/db /data/configdb && \

--- a/images/mysql/8.0.Dockerfile
+++ b/images/mysql/8.0.Dockerfile
@@ -44,6 +44,8 @@ RUN microdnf install -y epel-release \
         gettext \
         net-tools \
         pwgen \
+        rsync \
+        tar \
         wget; \
     rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
     curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl

--- a/images/mysql/8.4.Dockerfile
+++ b/images/mysql/8.4.Dockerfile
@@ -43,6 +43,8 @@ RUN microdnf install -y epel-release \
         gettext \
         net-tools \
         pwgen \
+        rsync \
+        tar \
         wget; \
     rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf*; \
     curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -23,8 +23,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mari
         patch \
         postgresql-client \
         procps \
-        rsync \
-        tar \
         unzip \
     && rm -rf /var/cache/apk/* \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -23,8 +23,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mari
         patch \
         postgresql-client \
         procps \
-        rsync \
-        tar \
         unzip \
     && rm -rf /var/cache/apk/* \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -23,8 +23,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mari
         patch \
         postgresql-client \
         procps \
-        rsync \
-        tar \
         unzip \
     && rm -rf /var/cache/apk/* \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -14,6 +14,10 @@ LABEL org.opencontainers.image.base.name="docker.io/node:18-alpine3.20"
 
 ENV LAGOON=node
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -14,6 +14,10 @@ LABEL org.opencontainers.image.base.name="docker.io/node:20-alpine3.20"
 
 ENV LAGOON=node
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/

--- a/images/node/22.Dockerfile
+++ b/images/node/22.Dockerfile
@@ -14,6 +14,10 @@ LABEL org.opencontainers.image.base.name="docker.io/node:22-alpine3.20"
 
 ENV LAGOON=node
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -29,7 +29,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mari
         patch \
         postgresql-client \
         procps \
-        rsync \
         unzip \
         yarn \
     && rm -rf /var/cache/apk/* \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -29,7 +29,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mari
         patch \
         postgresql-client \
         procps \
-        rsync \
         unzip \
         yarn \
     && rm -rf /var/cache/apk/* \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -29,7 +29,6 @@ RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mari
         patch \
         postgresql-client \
         procps \
-        rsync \
         unzip \
         yarn \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -115,7 +115,9 @@ RUN apk update \
         libxslt \
         libzip \
         postgresql-libs \
+        rsync \
         ssmtp \
+        tar \
         tidyhtml \
         unzip \
         yaml \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -115,7 +115,9 @@ RUN apk update \
         libxslt \
         libzip \
         postgresql-libs \
+        rsync \
         ssmtp \
+        tar \
         tidyhtml \
         unzip \
         yaml \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -115,7 +115,9 @@ RUN apk update \
         libxslt \
         libzip \
         postgresql-libs \
+        rsync \
         ssmtp \
+        tar \
         tidyhtml \
         unzip \
         yaml \

--- a/images/rabbitmq/Dockerfile
+++ b/images/rabbitmq/Dockerfile
@@ -14,6 +14,10 @@ LABEL org.opencontainers.image.base.name="docker.io/rabbitmq:3-management-alpine
 
 ENV LAGOON=rabbitmq
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 ENV RABBITMQ_DEFAULT_USER='guest' \
     RABBITMQ_DEFAULT_PASS='guest'\
     RABBITMQ_DEFAULT_HA_PATTERN='^$'\

--- a/images/redis/6.Dockerfile
+++ b/images/redis/6.Dockerfile
@@ -16,6 +16,10 @@ ENV LAGOON=redis
 
 ENV FLAVOR=ephemeral
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/

--- a/images/redis/7.Dockerfile
+++ b/images/redis/7.Dockerfile
@@ -16,6 +16,10 @@ ENV LAGOON=redis
 
 ENV FLAVOR=ephemeral
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/

--- a/images/solr/9.Dockerfile
+++ b/images/solr/9.Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get -y update \
     && apt-get -y install \
                   busybox \
                   curl \
+                  rsync \
+                  tar \
                   zip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/images/valkey/8.Dockerfile
+++ b/images/valkey/8.Dockerfile
@@ -17,6 +17,10 @@ ENV LAGOON=valkey
 
 ENV FLAVOR=ephemeral
 
+RUN apk add --no-cache \
+        rsync \
+        tar
+
 # Copy commons files
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/


### PR DESCRIPTION
In #891 we added rsync and tar to images - this PR goes further, adding them to more images, and moving them into the php/node web images instead of the cli images.