### PR TITLE
build: fix minimum rsync versions for solr images

### DIFF
--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -37,9 +37,10 @@ RUN apt-get -y update \
     && apt-get -y install \
         busybox \
         curl \
-        rsync \
         tar \
         zip \
+    # Temp fix for rsync RCE vulnerability https://ubuntu.com/blog/rsync-remote-code-execution
+    && apt satisfy -y "rsync (>= 3.1.3-8ubuntu0.8)" \
     && rm -rf /var/lib/apt/lists/*
 
 # Mitigation for CVE-2021-45046 and CVE-2021-44228 - not needed in log4j-core 2.16.0

--- a/images/solr/9.Dockerfile
+++ b/images/solr/9.Dockerfile
@@ -35,16 +35,13 @@ USER root
 
 RUN apt-get -y update \
     && apt-get -y install \
-                  busybox \
-                  curl \
-                  rsync \
-                  tar \
-                  zip \
+        busybox \
+        curl \
+        tar \
+        zip \
+    # Temp fix for rsync RCE vulnerability https://ubuntu.com/blog/rsync-remote-code-execution
+    && apt satisfy -y "rsync (>= 3.1.3-8ubuntu0.8)" \
     && rm -rf /var/lib/apt/lists/*
-
-# Mitigation for CVE-2021-45046 and CVE-2021-44228 - not needed in log4j-core 2.16.0
-#  RUN zip -q -d /opt/solr-8.10.1/server/lib/ext/log4j-core-2.14.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
-#      && zip -q -d /opt/solr-8.10.1/contrib/prometheus-exporter/lib/log4j-core-2.14.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
     && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini


### PR DESCRIPTION
To fix the package versions for rsync in the solr images - https://ubuntu.com/blog/rsync-remote-code-execution - we've introduced a minimum version fix