### PR TITLE
chore: upgrade musl to fix node install in php images

### DIFF
--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -13,13 +13,13 @@ Run the following commands to get up and running with this example.
 sed -i -e "/###/d" *-docker-compose.yml
 cp images-docker-compose.yml docker-compose.yml
 docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
-docker-compose down
+docker compose down
 
 # pull any required images
-docker-compose pull || true
+docker compose pull || true
 
 # should start up our services successfully
-docker-compose build && docker-compose up -d
+docker compose build && docker compose up -d
 
 # Ensure long-running pods are ready to connect
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://php-8-1-dev:9000 -timeout 1m
@@ -331,6 +331,6 @@ Run the following commands to trash this app like nothing ever happened.
 
 ```bash
 # should be able to destroy our services with success
-docker-compose down --volumes --remove-orphans
+docker compose down --volumes --remove-orphans
 rm docker-compose.yml
 ```

--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -13,13 +13,13 @@ Run the following commands to get up and running with this example.
 sed -i -e "/###/d" *-docker-compose.yml
 cp services-docker-compose.yml docker-compose.yml
 docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
-docker-compose down
+docker compose down
 
 # pull any required images
-docker-compose pull || true
+docker compose pull || true
 
 # should start up our services successfully
-docker-compose build && docker-compose up -d
+docker compose build && docker compose up -d
 
 # Ensure database pods are ready to connect
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-4:3306 -timeout 1m
@@ -406,6 +406,6 @@ Run the following commands to trash this app like nothing ever happened.
 
 ```bash
 # should be able to destroy our services with success
-docker-compose down --volumes --remove-orphans
+docker compose down --volumes --remove-orphans
 rm docker-compose.yml
 ```

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -16,6 +16,7 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -16,6 +16,7 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -16,6 +16,7 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -16,6 +16,7 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
+    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \


### PR DESCRIPTION
Small change to ensure node installs with full compatibility into the PHP images. May not be needed forever, but arises because the base image is behind the added package. We don't usually upgrade base packages unless something's broken.

Also tidied some old docker-compose references that slipped through