### PR TITLE
chore: add util-linux-core to provide flock for cron

### DIFF
--- a/images/opensearch/2.Dockerfile
+++ b/images/opensearch/2.Dockerfile
@@ -26,6 +26,7 @@ RUN dnf update --releasever=latest -y \
         findutils \
         rsync \
         tar \
+        util-linux-core \
     && dnf clean all
 
 RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \

--- a/images/php-fpm/8.4.Dockerfile
+++ b/images/php-fpm/8.4.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \


### PR DESCRIPTION
Once https://github.com/uselagoon/build-deploy-tool/pull/192 is released, all images that may have cronjobs need to have the flock binary to run them. In testing, only Opensearch-2 was missing it, hence the addition here, in case anyone wants cron!