### PR TITLE
chore: move musl upgrade to php-fpm

### DIFF
--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -16,7 +16,6 @@ ENV LAGOON=cli
 STOPSIGNAL SIGTERM
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk upgrade --available musl \
     && apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \

--- a/images/php-fpm/8.4.Dockerfile
+++ b/images/php-fpm/8.4.Dockerfile
@@ -50,6 +50,7 @@ COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.7 /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN apk update \
+    && apk upgrade --available musl \
     && apk add --no-cache --virtual .devdeps \
         # for gd
         freetype-dev \


### PR DESCRIPTION
In #1223 a musl upgrade was needed to install the latest node packages. This can cause an apk dependency mismatch, so moving it to base image ensures correct resolution.