### PR TITLE
SOLR: Fix for solr 9.8 breaking changes in module handling

### DIFF
--- a/images/solr-drupal/9.Dockerfile
+++ b/images/solr-drupal/9.Dockerfile
@@ -19,4 +19,6 @@ LABEL org.opencontainers.image.base.name="docker.io/uselagoon/solr-9"
 COPY --from=jumpstart /search_api_solr/jump-start/solr9/config-set /solr-conf/conf
 ENV SOLR_INSTALL_DIR=/opt/solr
 
+ENV SOLR_MODULES="extraction,langid,ltr,analysis-extras"
+
 CMD ["solr-precreate", "drupal", "/solr-conf"]


### PR DESCRIPTION
The `<lib/>` directives as used by Drupals search_api_solr are no longer supported: https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-9-8 

Related d.o. issue https://www.drupal.org/project/search_api_solr/issues/3508084

---

I think adding the modules used by the jump-start config is fair. 
I think we should _not_ enable the `<lib/>` directives via workaround property since the directives will be gone in Solr 10 anyway.