### PR TITLE
update mariadb-client to the latest available version in alpine packages

### DIFF
--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons AS commons
-FROM alpine:3.19.7
+FROM alpine:3.20.6
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION
@@ -43,10 +43,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=10.11.6-r0 \
-        mariadb-common=10.11.6-r0 \
-        mariadb-server-utils=10.11.6-r0 \
-        mariadb=10.11.6-r0 \
+        mariadb-client=10.11.11-r0 \
+        mariadb-common=10.11.11-r0 \
+        mariadb-server-utils=10.11.11-r0 \
+        mariadb=10.11.11-r0 \
         mariadb-connector-c \
         net-tools \
         perl-doc \

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -11,12 +11,13 @@ LABEL org.opencontainers.image.description="Node.js 18 cli image optimised for r
 LABEL org.opencontainers.image.title="uselagoon/node-18-cli"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-18"
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         openssh-client \
         openssh-sftp-server \

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -11,12 +11,13 @@ LABEL org.opencontainers.image.description="Node.js 20 cli image optimised for r
 LABEL org.opencontainers.image.title="uselagoon/node-20-cli"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-20"
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         openssh-client \
         openssh-sftp-server \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -11,12 +11,13 @@ LABEL org.opencontainers.image.description="Node.js 22 cli image optimised for r
 LABEL org.opencontainers.image.title="uselagoon/node-22-cli"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-22"
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli-drupal/drush.yml
+++ b/images/php-cli-drupal/drush.yml
@@ -4,3 +4,12 @@
 options:
   root: '/app/${env.WEBROOT}'
   uri: '${env.LAGOON_ROUTE}'
+
+command:
+  sql:
+    cli:
+      options:
+        extra: '--disable-ssl'
+    dump:
+      options:
+        extra-dump: '--disable-ssl'

--- a/images/php-cli-drupal/drush.yml
+++ b/images/php-cli-drupal/drush.yml
@@ -10,6 +10,9 @@ command:
     cli:
       options:
         extra: '--disable-ssl'
+    query:
+      options:
+        extra: '--disable-ssl'
     dump:
       options:
         extra-dump: '--disable-ssl'

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -15,12 +15,13 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \
         npm \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -15,12 +15,13 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \
         npm \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -15,12 +15,13 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \
         npm \

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -15,12 +15,13 @@ ENV LAGOON=cli
 
 STOPSIGNAL SIGTERM
 
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/v3.19/main mariadb-client=10.11.6-r0 mariadb-connector-c \
-    && apk add --no-cache bash \
+RUN apk add --no-cache bash \
         coreutils \
         findutils \
         git \
         gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \
         npm \

--- a/images/php-cli/mariadb-client.cnf
+++ b/images/php-cli/mariadb-client.cnf
@@ -1,2 +1,5 @@
 [client]
 max_allowed_packet = ${MARIADB_MAX_ALLOWED_PACKET:-64M}
+
+[client-mariadb]
+ssl=0


### PR DESCRIPTION
In https://github.com/uselagoon/lagoon-images/pull/1031 we pinned the versions of mariadb-client in use in Lagoon Images, to avoid having to deal with the sandboxing introduced in https://mariadb.org/mariadb-dump-file-compatibility-change/

In this PR, we update the versions of mariadb-client used for all CLI images (as well as the 10.11 server image). One complication of this is that the mariadb-client in version 11.4 enables SSL mode on connections by default. As Lagoon uses only internal traffic for database connections locally and in the cloud, we do not have SSL configured. I have added the necessary configuration to the default drush and mariadb-dump commands to cover most scenarios.

This now means that any dump taken (via drush, wp-cli, mariadb-dump) in a cli pod will be taken in "sandbox" mode. This is a security improvement, but may cause inadvertent side-effects if different versions of the client packages are used in different environments (production, development, local).

The error most commly manifests in this message:
```
    Query failed. Rerun with --debug to see any error message. ERROR at line   
  1:                                                                           
     Unknown command '\-'.
```

To minimise the potential impact, wherever possible, all environments should be running the same (ie 25.3.0 onwards) release of lagoon-images to ensure that the taken dump can be re-imported. There are troubleshooting steps in the linked mariadb change page.

If you are using drush, you can also use the host binary to take a dump of a remote site like so
```
drush @lagoon.project-environment sql-dump > /tmp/dump.sql
```

