### PR TITLE
fix: $PATH is different when starting subshells

### DIFF
--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -30,8 +30,6 @@ RUN apk add --no-cache bash \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
 COPY entrypoints /lagoon/entrypoints/
 
 # Make sure shells are not running forever

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -30,8 +30,6 @@ RUN apk add --no-cache bash \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
 COPY entrypoints /lagoon/entrypoints/
 
 # Make sure shells are not running forever

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -30,8 +30,6 @@ RUN apk add --no-cache bash \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
 COPY entrypoints /lagoon/entrypoints/
 
 # Make sure shells are not running forever

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -44,8 +44,7 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
 ENV PATH="/home/.composer/vendor/bin:${PATH}"
 
 COPY entrypoints /lagoon/entrypoints/
-COPY legacy-entrypoints /lagoon/entrypoints/90-composer-path.sh
-
+COPY legacy-entrypoints /lagoon/entrypoints/
 
 # Remove warning about running as root in composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -40,11 +40,12 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# Adding Composer vendor bin path to $PATH.
+# Changes to $PATH MUST be duplicated in /lagoon/entrypoints/90-composer-paths.sh
 ENV PATH="/home/.composer/vendor/bin:${PATH}"
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
+
 COPY entrypoints /lagoon/entrypoints/
+COPY legacy-entrypoints /lagoon/entrypoints/90-composer-path.sh
+
 
 # Remove warning about running as root in composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -44,7 +44,7 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
 ENV PATH="/home/.composer/vendor/bin:${PATH}"
 
 COPY entrypoints /lagoon/entrypoints/
-COPY legacy-entrypoints /lagoon/entrypoints/90-composer-path.sh
+COPY legacy-entrypoints /lagoon/entrypoints/
 
 # Remove warning about running as root in composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -40,11 +40,11 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# Adding Composer vendor bin path to $PATH.
+# Changes to $PATH MUST be duplicated in /lagoon/entrypoints/90-composer-paths.sh
 ENV PATH="/home/.composer/vendor/bin:${PATH}"
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
+
 COPY entrypoints /lagoon/entrypoints/
+COPY legacy-entrypoints /lagoon/entrypoints/90-composer-path.sh
 
 # Remove warning about running as root in composer
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -40,10 +40,8 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# Adding Composer vendor bin directories to $PATH.
+# Changes to $PATH MUST be duplicated in /lagoon/entrypoints/90-composer-paths.sh
 ENV PATH="$PATH:/app/vendor/bin:/home/.composer/vendor/bin"
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
 
 COPY entrypoints /lagoon/entrypoints/
 

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -40,10 +40,8 @@ RUN curl -L -o /usr/local/bin/composer https://github.com/composer/composer/rele
     && mkdir -p /home/.ssh \
     && fix-permissions /home/
 
-# Adding Composer vendor bin directories to $PATH.
+# Changes to $PATH MUST be duplicated in /lagoon/entrypoints/90-composer-paths.sh
 ENV PATH="$PATH:/app/vendor/bin:/home/.composer/vendor/bin"
-# We not only use "export $PATH" as this could be overwritten again
-# like it happens in /etc/profile of alpine Images.
 
 COPY entrypoints /lagoon/entrypoints/
 

--- a/images/php-cli/legacy-entrypoints/90-composer-path.sh
+++ b/images/php-cli/legacy-entrypoints/90-composer-path.sh
@@ -7,10 +7,9 @@ add_to_PATH () {
   for d; do
     case ":$PATH:" in
       *":$d:"*) :;;
-      *) PATH=$PATH:$d;;
+      *) PATH=$d:$PATH;;
     esac
   done
 }
 
-add_to_PATH /app/vendor/bin
 add_to_PATH /home/.composer/vendor/bin


### PR DESCRIPTION
Fixes #1265 

Before this PR:

```
cli-drupal:/app$ env | grep -i path
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/vendor/bin:/home/.composer/vendor/bin:/app/vendor/bin
cli-drupal:/app$ bash -l
cli-drupal:/app$ env | grep -i path
PATH=/home/.composer/vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

With this PR:

```
cli-drupal:/app$ env | grep -i path
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/vendor/bin:/home/.composer/vendor/bin
cli-drupal:/app$ bash -l
cli-drupal:/app$ env | grep -i path
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/vendor/bin:/home/.composer/vendor/bin
```

I didn't spend a lot of time thinking how to keep the php 8.1/8.2 images backwards compatible. Happy to entertain ideas other than the `legacy-endpoints` folder.