### PR TITLE
chore: add deprecated label to MariaDB 10.4 and 10.5

### DIFF
--- a/images/mariadb-drupal/10.4.Dockerfile
+++ b/images/mariadb-drupal/10.4.Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.description="MariaDB 10.4 image optimised for Dru
 LABEL org.opencontainers.image.title="uselagoon/mariadb-10.4-drupal"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/mariadb-10.4"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/mariadb-10.11-drupal"
+
 ENV MARIADB_DATABASE=drupal \
     MARIADB_USER=drupal \
     MARIADB_PASSWORD=drupal

--- a/images/mariadb-drupal/10.5.Dockerfile
+++ b/images/mariadb-drupal/10.5.Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.description="MariaDB 10.5 image optimised for Dru
 LABEL org.opencontainers.image.title="uselagoon/mariadb-10.5-drupal"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/mariadb-10.5"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/mariadb-10.11-drupal"
+
 ENV MARIADB_DATABASE=drupal \
     MARIADB_USER=drupal \
     MARIADB_PASSWORD=drupal

--- a/images/mariadb/10.4.Dockerfile
+++ b/images/mariadb/10.4.Dockerfile
@@ -13,6 +13,9 @@ LABEL org.opencontainers.image.description="MariaDB 10.4 image optimised for run
 LABEL org.opencontainers.image.title="uselagoon/mariadb-10.4"
 LABEL org.opencontainers.image.base.name="docker.io/alpine:3.12"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/mariadb-10.11"
+
 ENV LAGOON=mariadb
 
 # Copy commons files

--- a/images/mariadb/10.5.Dockerfile
+++ b/images/mariadb/10.5.Dockerfile
@@ -13,6 +13,9 @@ LABEL org.opencontainers.image.description="MariaDB 10.5 image optimised for run
 LABEL org.opencontainers.image.title="uselagoon/mariadb-10.5"
 LABEL org.opencontainers.image.base.name="docker.io/alpine:3.14"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/mariadb-10.11"
+
 ENV LAGOON=mariadb
 
 # Copy commons files


### PR DESCRIPTION
This PR is the first step in deprecating the publication of MariaDB 10.4 and 10.5 images, which are both now built using very superseded Alpine images.