### PR TITLE
chore: add disable-ssl override to all drush commands

### DIFF
--- a/images/php-cli-drupal/drush.yml
+++ b/images/php-cli-drupal/drush.yml
@@ -15,4 +15,15 @@ command:
         extra: '--disable-ssl'
     dump:
       options:
+        extra: '--disable-ssl'
         extra-dump: '--disable-ssl'
+    drop:
+      options:
+        extra: '--disable-ssl'
+    create:
+      options:
+        extra: '--disable-ssl'
+  site:
+    install:
+      options:
+        extra: '--disable-ssl'


### PR DESCRIPTION
Now that https://github.com/drush-ops/drush/pull/6249 has been added to drush, this adds the necessary options to all drush subcommands.

Closes #1273 