### PR TITLE
build: initial redis-8 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ versioned-images := 		mariadb-10.6 \
 							redis-6-persistent \
 							redis-7 \
 							redis-7-persistent \
+							redis-8 \
 							ruby-3.1 \
 							ruby-3.2 \
 							ruby-3.3 \
@@ -296,7 +297,7 @@ build/postgres-15-drupal: build/postgres-15
 build/postgres-16-drupal: build/postgres-16
 build/postgres-17-drupal: build/postgres-17
 build/python-3.9 build/python-3.10 build/python-3.11 build/python-3.12 build/python-3.13: build/commons
-build/redis-6 build/redis-7: build/commons
+build/redis-6 build/redis-7 build/redis-8: build/commons
 build/redis-6-persistent: build/redis-6
 build/redis-7-persistent: build/redis-7
 build/ruby-3.1 build/ruby-3.2 build/ruby-3.3 build/ruby-3.4: build/commons

--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -40,6 +40,7 @@ docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp:/
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://rabbitmq:15672 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-6:6379 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-7:6379 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-8:6379 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://solr-8:8983 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://solr-9:8983 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://valkey-8:6379 -timeout 1m
@@ -70,6 +71,7 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep rabbitmq
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-6
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-7
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep solr-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep solr-9
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep valkey-8
@@ -315,6 +317,19 @@ docker compose exec -T redis-7 sh -c "redis-cli dbsize"
 # redis-7 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis?service=redis-7" | grep "SERVICE_HOST=redis-7"
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis?service=redis-7" |grep "LAGOON_TEST_VAR=all-images"
+
+# redis-8 should be running Redis v8.0
+docker compose exec -T redis-8 sh -c "redis-server --version" | grep v=8.
+
+# redis-8 should be able to see Redis databases
+docker compose exec -T redis-8 sh -c "redis-cli CONFIG GET databases"
+
+# redis-8 should have initialized database
+docker compose exec -T redis-8 sh -c "redis-cli dbsize"
+
+# redis-8 should be able to read/write data
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis?service=redis-8" | grep "SERVICE_HOST=redis-8"
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/redis?service=redis-8" |grep "LAGOON_TEST_VAR=all-images"
 
 # solr-8 should have a "mycore" Solr core
 docker compose exec -T commons sh -c "curl solr-8:8983/solr/admin/cores?action=STATUS\&core=mycore"

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -131,6 +131,12 @@ services:
       - "6379"
     << : *default-user
 
+  redis-8:
+    image: uselagoon/redis-8:latest
+    ports:
+      - "6379"
+    << : *default-user # uses the defined user from top
+
   solr-8:
     image: uselagoon/solr-8:latest
     ports:

--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=envplate /usr/local/bin/ep /bin/ep
 
 RUN apk update \
     && apk add --no-cache \
+        apk-tools-static \
         curl \
         rsync \
         tar \

--- a/images/redis/8.Dockerfile
+++ b/images/redis/8.Dockerfile
@@ -1,0 +1,57 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
+FROM redis:8.0.0-alpine3.21
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Redis 8 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/redis-8"
+LABEL org.opencontainers.image.base.name="docker.io/redis:8-alpine3.21"
+
+ENV LAGOON=redis
+
+ENV FLAVOR=ephemeral
+
+# Temp workaround for https://github.com/redis/docker-library-redis/issues/444
+COPY --from=commons /sbin/apk.static /tmp/apk.static
+
+RUN /tmp/apk.static -X http://dl-cdn.alpinelinux.org/alpine/v3.21/main -U --allow-untrusted --initdb add apk-tools-static \
+    && /tmp/apk.static update \
+    && /tmp/apk.static -X http://dl-cdn.alpinelinux.org/alpine/v3.21/main -U --allow-untrusted add apk-tools \
+    && apk update \
+    && apk --repository http://dl-cdn.alpinelinux.org/alpine/v3.21/main/ --allow-untrusted --no-cache add rsync tar \
+    && rm /tmp/apk.static
+
+# RUN apk add --no-cache \
+#         rsync \
+#         tar
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+COPY conf /etc/redis/
+COPY docker-entrypoint /lagoon/entrypoints/70-redis-entrypoint
+
+RUN fix-permissions /etc/redis \
+    fix-permissions /data
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["redis-server", "/etc/redis/redis.conf"]

--- a/images/redis/docker-entrypoint
+++ b/images/redis/docker-entrypoint
@@ -8,6 +8,14 @@ if [[ -n "${REDIS_PASSWORD}" ]]; then
 requirepass ${REDIS_PASSWORD}"
 fi
 
+# Check if REDIS_FLAVOR or FLAVOR is set and has the value "persistent"
+if [ "${REDIS_FLAVOR}" = "persistent" ] || [ "${FLAVOR}" = "persistent" ]; then
+    FLAVOR="persistent"
+else
+    FLAVOR="ephemeral"
+fi
+echo "FLAVOR is set to: $FLAVOR"
+
 ep /etc/redis/*
 
 exec "$@"


### PR DESCRIPTION
Now that Redis is again published as AGPLv3 https://redis.io/blog/redis-8-ga/ we can re-add updated Redis images as well as Valkey-based ones.

Note that as per Valkey-based images, there is no seperate redis-8-persistent image, instead setting `REDIS_FLAVOR=persistent` as an env var will activate the persistent storage option