### PR TITLE
add node-24 images, mark node-18 deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,9 @@ versioned-images := 		mariadb-10.6 \
 							node-22 \
 							node-22-builder \
 							node-22-cli \
+							node-24 \
+							node-24-builder \
+							node-24-cli \
 							opensearch-2 \
 							opensearch-3 \
 							php-8.1-fpm \
@@ -272,10 +275,11 @@ build/mariadb-10.6-drupal: build/mariadb-10.6
 build/mariadb-10.11-drupal: build/mariadb-10.11
 build/mongo-4: build/commons
 build/mysql-8.0 build/mysql-8.4: build/commons
-build/node-18 build/node-20 build/node-22: build/commons
+build/node-18 build/node-20 build/node-22 build/node-24: build/commons
 build/node-18-builder build/node-18-cli: build/node-18
 build/node-20-builder build/node-20-cli: build/node-20
 build/node-22-builder build/node-22-cli: build/node-22
+build/node-24-builder build/node-24-cli: build/node-24
 build/opensearch-2: build/commons
 build/opensearch-3: build/commons
 build/php-8.1-fpm build/php-8.2-fpm build/php-8.3-fpm build/php-8.4-fpm: build/commons

--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -39,6 +39,7 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-18
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-20
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-22
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-24
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-1-dev
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-1-prod
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-dev
@@ -297,6 +298,12 @@ docker compose exec -T node-22 sh -c "node -v" | grep "v22"
 
 # node-22 should be serving content
 docker compose exec -T commons sh -c "curl node-22:3000/test" | grep "v22"
+
+# node-24 should have Node 24
+docker compose exec -T node-24 sh -c "node -v" | grep "v24"
+
+# node-24 should be serving content
+docker compose exec -T commons sh -c "curl node-24:3000/test" | grep "v24"
 
 # ruby-3-2 should have Ruby 3.2
 docker compose exec -T ruby-3-2 sh -c "ruby -v" | grep "3.2"

--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -41,6 +41,17 @@ services:
         exec http-server -p 3000
         "]
 
+  node-24:
+    image: uselagoon/node-24:latest
+    ports:
+      - "3000"
+    user: root
+    command: ["sh", "-c", "
+        npm install -g http-server;
+        node -v | xargs > /app/test.html;
+        exec http-server -p 3000
+        "]
+
   php-8-1-dev:
     image: uselagoon/php-8.1-cli:latest
     ports:

--- a/images/node-builder/18.Dockerfile
+++ b/images/node-builder/18.Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.description="Node.js 18 builder image optimised f
 LABEL org.opencontainers.image.title="uselagoon/node-18-builder"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-18"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/node-24-builder"
+
 RUN apk update \
     && apk add --no-cache \
        libstdc++ \

--- a/images/node-builder/24.Dockerfile
+++ b/images/node-builder/24.Dockerfile
@@ -1,0 +1,37 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/node-24
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-builder/24.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 24 builder image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-24-builder"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-24"
+
+RUN apk update \
+    && apk add --no-cache \
+       libstdc++ \
+    && apk add --no-cache \
+       bash \
+       binutils-gold \
+       ca-certificates \
+       curl \
+       file \
+       g++ \
+       gcc \
+       gcompat \
+       git \
+       gnupg \
+       libgcc \
+       libpng-dev \
+       linux-headers \
+       make \
+       openssl \
+       python3 \
+       wget \
+    && rm -rf /var/cache/apk/*
+
+CMD ["/bin/docker-sleep"]

--- a/images/node-cli/18.Dockerfile
+++ b/images/node-cli/18.Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.description="Node.js 18 cli image optimised for r
 LABEL org.opencontainers.image.title="uselagoon/node-18-cli"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-18"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/node-24-cli"
+
 RUN apk add --no-cache bash \
         coreutils \
         findutils \

--- a/images/node-cli/24.Dockerfile
+++ b/images/node-cli/24.Dockerfile
@@ -1,0 +1,48 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/node-24
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-cli/24.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 24 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-24-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-24"
+
+RUN apk add --no-cache bash \
+        coreutils \
+        findutils \
+        git \
+        gzip  \
+        mariadb-client=11.4.5-r0 \
+        mariadb-connector-c \
+        mongodb-tools \
+        openssh-client \
+        openssh-sftp-server \
+        patch \
+        postgresql-client \
+        procps \
+        unzip \
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+    && mkdir -p /home/.ssh \
+    && fix-permissions /home/
+
+COPY entrypoints /lagoon/entrypoints/
+
+# Make sure shells are not running forever
+RUN echo "source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+
+# Copy mariadb-client configuration.
+COPY mariadb-client.cnf /etc/my.cnf.d/
+RUN fix-permissions /etc/my.cnf.d/
+
+# SSH Key and Agent Setup
+COPY ssh_config /etc/ssh/ssh_config
+RUN sed -i '/# Deprecated: lagoon_cli.key/,+2d' /etc/ssh/ssh_config
+ENV SSH_AUTH_SOCK=/tmp/ssh-agent
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/bin/docker-sleep"]

--- a/images/node/18.Dockerfile
+++ b/images/node/18.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.opencontainers.image.description="Node.js 18 image optimised for runni
 LABEL org.opencontainers.image.title="uselagoon/node-18"
 LABEL org.opencontainers.image.base.name="docker.io/node:18-alpine3.21"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/node-24"
+
 ENV LAGOON=node
 
 RUN apk add --no-cache \

--- a/images/node/24.Dockerfile
+++ b/images/node/24.Dockerfile
@@ -1,0 +1,53 @@
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO:-lagoon}/commons AS commons
+FROM node:24.2-alpine3.21
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/24.Dockerfile"
+LABEL org.opencontainers.image.url="https://github.com/uselagoon/lagoon-images"
+LABEL org.opencontainers.image.version="${LAGOON_VERSION}"
+LABEL org.opencontainers.image.description="Node.js 24 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-24"
+LABEL org.opencontainers.image.base.name="docker.io/node:24-alpine3.21"
+
+ENV LAGOON=node
+
+RUN apk add --no-cache \
+        rsync \
+        tar
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home \
+    && fix-permissions /home \
+    && mkdir -p /app \
+    && fix-permissions /app
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+# Make sure Bower and NPM are allowed to be running as root
+RUN echo '{ "allow_root": true }' > /home/.bowerrc \
+    && echo 'unsafe-perm=true' > /home/.npmrc
+
+WORKDIR /app
+
+EXPOSE 3000
+
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=3000
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["yarn", "run", "start"]


### PR DESCRIPTION
Now that Node 24 has been released, and Node 18 EOL, we should add the new images, and mark the old ones ready to deprecate, pending removal next release.