### PR TITLE
chore: add brotli and avif support to PHP images

### DIFF
--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -66,6 +66,7 @@ docker compose exec -T php-8-2-dev bash -c "php -i" | grep "PHP Version" | grep 
 
 # PHP 8.2 development should have modules enabled
 docker compose exec -T commons sh -c "curl -kL http://php-8-2-dev:9000" | grep "APCu Support" | grep "Enabled"
+docker compose exec -T commons sh -c "curl -kL http://php-8-2-dev:9000" | grep "Brotli support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-2-dev:9000" | grep "LibYAML Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-2-dev:9000" | grep "Redis Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-2-dev:9000" | grep "imagick module" | grep "enabled"
@@ -109,6 +110,7 @@ docker compose exec -T php-8-3-dev bash -c "php -i" | grep "PHP Version" | grep 
 
 # PHP 8.3 development should have modules enabled
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "APCu Support" | grep "Enabled"
+docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "Brotli support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "LibYAML Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "Redis Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-3-dev:9000" | grep "imagick module" | grep "enabled"
@@ -152,6 +154,7 @@ docker compose exec -T php-8-4-dev bash -c "php -i" | grep "PHP Version" | grep 
 
 # PHP 8.4 development should have modules enabled
 docker compose exec -T commons sh -c "curl -kL http://php-8-4-dev:9000" | grep "APCu Support" | grep "Enabled"
+docker compose exec -T commons sh -c "curl -kL http://php-8-4-dev:9000" | grep "Brotli support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-4-dev:9000" | grep "LibYAML Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-4-dev:9000" | grep "Redis Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-4-dev:9000" | grep "imagick module" | grep "enabled"
@@ -195,6 +198,7 @@ docker compose exec -T php-8-5-dev bash -c "php -i" | grep "PHP Version" | grep 
 
 # PHP 8.5 development should have modules enabled
 docker compose exec -T commons sh -c "curl -kL http://php-8-5-dev:9000" | grep "APCu Support" | grep "Enabled"
+docker compose exec -T commons sh -c "curl -kL http://php-8-5-dev:9000" | grep "Brotli support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-5-dev:9000" | grep "LibYAML Support" | grep "enabled"
 docker compose exec -T commons sh -c "curl -kL http://php-8-5-dev:9000" | grep "Redis Support" | grep "enabled"
 # docker compose exec -T commons sh -c "curl -kL http://php-8-5-dev:9000" | grep "imagick module" | grep "enabled"

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -63,6 +63,9 @@ RUN apk update \
         gettext-dev \
         # for imagemagick
         imagemagick-dev \
+        # for gd
+        libavif-dev \
+        # for imagemagick
         libgcrypt-dev \
         # for gd
         libjpeg-turbo-dev \
@@ -85,12 +88,13 @@ RUN apk update \
         # for yaml
         yaml-dev \
     && pie install apcu/apcu:5.1.28 \
+    && pie install kjdev/brotli:0.18.3 \
     && pie install imagick/imagick:3.8.1 \
     && pie install phpredis/phpredis:6.3.0 \
     && pie install xdebug/xdebug:3.5.1 \
     && pie install pecl/yaml:2.3.0 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype --with-avif \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
         .devdeps \
@@ -113,6 +117,7 @@ RUN apk update \
         imagemagick-webp \
         imagemagick-svg \
         imagemagick-tiff \
+        libavif \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -63,6 +63,9 @@ RUN apk update \
         gettext-dev \
         # for imagemagick
         imagemagick-dev \
+        # for gd
+        libavif-dev \
+        # for imagemagick
         libgcrypt-dev \
         # for gd
         libjpeg-turbo-dev \
@@ -85,12 +88,13 @@ RUN apk update \
         # for yaml
         yaml-dev \
     && pie install apcu/apcu:5.1.28 \
+    && pie install kjdev/brotli:0.18.3 \
     && pie install imagick/imagick:3.8.1 \
     && pie install phpredis/phpredis:6.3.0 \
     && pie install xdebug/xdebug:3.5.1 \
     && pie install pecl/yaml:2.3.0 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype --with-avif \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
         .devdeps \
@@ -113,6 +117,7 @@ RUN apk update \
         imagemagick-webp \
         imagemagick-svg \
         imagemagick-tiff \
+        libavif \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \

--- a/images/php-fpm/8.4.Dockerfile
+++ b/images/php-fpm/8.4.Dockerfile
@@ -63,6 +63,9 @@ RUN apk update \
         gettext-dev \
         # for imagemagick
         imagemagick-dev \
+        # for gd
+        libavif-dev \
+        # for imagemagick
         libgcrypt-dev \
         # for gd
         libjpeg-turbo-dev \
@@ -85,12 +88,13 @@ RUN apk update \
         # for yaml
         yaml-dev \
     && pie install apcu/apcu:5.1.28 \
+    && pie install kjdev/brotli:0.18.3 \
     && pie install imagick/imagick:3.8.1 \
     && pie install phpredis/phpredis:6.3.0 \
     && pie install xdebug/xdebug:3.5.1 \
     && pie install pecl/yaml:2.3.0 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype --with-avif \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql opcache pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
         .devdeps \
@@ -113,6 +117,7 @@ RUN apk update \
         imagemagick-webp \
         imagemagick-svg \
         imagemagick-tiff \
+        libavif \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \

--- a/images/php-fpm/8.5.Dockerfile
+++ b/images/php-fpm/8.5.Dockerfile
@@ -63,6 +63,9 @@ RUN apk update \
         gettext-dev \
         # for imagemagick
         imagemagick-dev \
+        # for gd
+        libavif-dev \
+        # for imagemagick
         libgcrypt-dev \
         # for gd
         libjpeg-turbo-dev \
@@ -85,12 +88,13 @@ RUN apk update \
         # for yaml
         yaml-dev \
     && pie install apcu/apcu:5.1.28 \
+    && pie install kjdev/brotli:0.18.3 \
     && pie install imagick/imagick:3.8.1 \
     && pie install phpredis/phpredis:6.3.0 \
     && pie install xdebug/xdebug:3.5.1 \
     && pie install pecl/yaml:2.3.0 \
     && sed -i '1s/^/;Intentionally disabled. Enable via setting env variable XDEBUG_ENABLE to true\n;/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype --with-avif \
     && docker-php-ext-install -j4 bcmath exif gd gettext intl mysqli pdo_mysql pdo_pgsql pgsql shmop soap sockets tidy xsl zip \
     && apk del -r \
         .devdeps \
@@ -113,6 +117,7 @@ RUN apk update \
         imagemagick-webp \
         imagemagick-svg \
         imagemagick-tiff \
+        libavif \
         libgcrypt \
         libjpeg-turbo \
         libmcrypt \


### PR DESCRIPTION
Brotli: now supported downstream in Drupal
> semi-dependent on https://www.drupal.org/node/3184242 (support in Drupal Core for Brotli)
AVIF: an optional requirement for Drupal CMS2+
