### PR TITLE
Revert "chore(deps): update mysql docker tag to v8.4.6 (main)"

### DIFF
--- a/images/mysql/8.4.Dockerfile
+++ b/images/mysql/8.4.Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REPO
 FROM ${IMAGE_REPO:-lagoon}/commons AS commons
-FROM mysql:8.4.6-oracle
+FROM mysql:8.4.5-oracle
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION


### PR DESCRIPTION
Reverts uselagoon/lagoon-images#1375

There's currently no ARM image, so this needs to be reverted for now