### PR TITLE
chore: update to mariadb-client-11.4.8-r0

### DIFF
--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node-cli/24.Dockerfile
+++ b/images/node-cli/24.Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.5-r2 \
+        mariadb-client=11.4.8-r0 \
         mariadb-connector-c \
         mongodb-tools \
         nodejs=~22 \


### PR DESCRIPTION
Unsure if we should re-detach the mariadb version - but I'm worried about it rolling too far forwards without us at least checking compatibility