### PR TITLE
chore: update version of mariadb-server 10.11

### DIFF
--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -43,10 +43,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=10.11.11-r0 \
-        mariadb-common=10.11.11-r0 \
-        mariadb-server-utils=10.11.11-r0 \
-        mariadb=10.11.11-r0 \
+        mariadb-client=10.11.14-r0 \
+        mariadb-common=10.11.14-r0 \
+        mariadb-server-utils=10.11.14-r0 \
+        mariadb=10.11.14-r0 \
         mariadb-connector-c \
         net-tools \
         perl-doc \


### PR DESCRIPTION
Alpine updated the version of the mariadb packages on 3.20 to 10.11.14
https://gitlab.alpinelinux.org/alpine/aports/-/commit/ae89d56a56b92c980eb20c5ec2d66e495064b9ed