### PR TITLE
build: deprecate solr-8 based images

### DIFF
--- a/images/solr-drupal/8.Dockerfile
+++ b/images/solr-drupal/8.Dockerfile
@@ -16,6 +16,9 @@ LABEL org.opencontainers.image.description="Solr 8 image optimised for Drupal wo
 LABEL org.opencontainers.image.title="uselagoon/solr-8-drupal"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/solr-8"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/solr-9-drupal"
+
 COPY --from=jumpstart /search_api_solr/jump-start/solr8/config-set /solr-conf/conf
 ENV SOLR_INSTALL_DIR=/opt/solr
 

--- a/images/solr/8.Dockerfile
+++ b/images/solr/8.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.opencontainers.image.description="Solr 8 image optimised for running i
 LABEL org.opencontainers.image.title="uselagoon/solr-8"
 LABEL org.opencontainers.image.base.name="docker.io/solr:8"
 
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/solr-9"
+
 ENV LAGOON=solr
 
 ENV SOLR_DATA_HOME=/var/solr


### PR DESCRIPTION
Solr 8 has been EOL since October 2024, but the base images continued to be updated until April 2025

This PR sets the labels to flag it for removal next month

closes #1412