### PR TITLE
Improve copilot contribution and review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,276 @@
+# Lagoon Base Images — AI Agent Instructions
+
+> **Architecture, naming, dependency model, build system, CI flow:**
+> see [architecture.md](../architecture.md). This file is intentionally
+> task-focused — it tells you **what to do**, not **why the repo is
+> shaped the way it is**.
+
+---
+
+## When reviewing a PR
+
+Use [docs/reviewing/PR_REVIEW_RUBRIC.md](../docs/reviewing/PR_REVIEW_RUBRIC.md).
+Focus on:
+
+1. **Correctness** — reproducible builds, explicit version pins.
+2. **Security** — no unverified external downloads, minimal attack surface.
+3. **Testing** — every new image / variant has compose + TESTING markdown coverage.
+4. **Clarity** — labels, comments, intent.
+5. **Performance** — minimal final image size.
+6. **Consistency** — naming, Dockerfile conventions, group/target wiring match the rest of the repo.
+7. **Backward compatibility** — no silent breaking changes.
+8. **Maintenance** — upstream version is current; deprecation labels present where applicable.
+
+Group findings by category. Skip nits already covered by linters.
+
+---
+
+## Recipe 1 — Add a new version of an existing service
+
+Example: adding `python-3.15`.
+
+### 1. Create the Dockerfile
+
+`images/python/3.15.Dockerfile`, following the **first-tier pattern**
+documented in [architecture.md §7.1](../architecture.md#71-first-tier-images-from-upstream).
+
+### 2. Update `docker-bake.hcl` — three edits, all required
+
+```hcl
+# (a) New target
+target "python-3-15" {
+  inherits   = ["default"]
+  context    = "images/python"
+  dockerfile = "3.15.Dockerfile"
+  tags       = tags("python-3.15")
+  contexts   = {
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+}
+
+# (b) Add to the service-specific group
+group "python" {
+  targets = [
+    "commons",
+    # … existing versions …
+    "python-3-15",
+  ]
+}
+
+# (c) Add to the default group
+group "default" {
+  targets = [
+    # … existing targets …
+    "python-3-15",
+    # … more targets …
+  ]
+}
+```
+
+> **Forgetting (b) or (c) means the image silently won't be built by CI.**
+
+Target names use dashes (`python-3-15`). Tags keep dots (`python-3.15`).
+
+### 3. Add test coverage
+
+- For a runtime/HTTP service: add a service block to
+  [helpers/images-docker-compose.yml](../helpers/images-docker-compose.yml)
+  and test commands to
+  [helpers/TESTING_base_images_dockercompose.md](../helpers/TESTING_base_images_dockercompose.md).
+- For a stateful service: same pattern in
+  [helpers/services-docker-compose.yml](../helpers/services-docker-compose.yml)
+  and [helpers/TESTING_service_images_dockercompose.md](../helpers/TESTING_service_images_dockercompose.md).
+
+### 4. Validate locally — non-negotiable
+
+```bash
+make build/python-3.15
+
+cp helpers/images-docker-compose.yml docker-compose.yml
+sed -i '' 's/uselagoon/lagoon/g' docker-compose.yml   # macOS sed
+docker compose up -d python-3-15 commons
+
+# Run EVERY new TESTING_*.md command for this image and confirm output
+docker compose exec -T python-3-15 sh -c "python --version" | grep "3.15"
+# … etc …
+
+docker ps --filter label=com.docker.compose.project=lagoon-images | grep Up | grep python-3-15
+
+docker compose down && rm docker-compose.yml
+```
+
+**Never copy version strings or grep patterns from another service
+without verifying against the actually-built image** — Redis, MariaDB
+and PHP have all caused CI failures this way.
+
+---
+
+## Recipe 2 — Add a new variant of an existing service
+
+Example: adding `service-X-persistent-drupal` for a service that already
+has `service-X` and `service-X-drupal`.
+
+### 1. Create the Dockerfile
+
+`images/service-persistent-drupal/X.Dockerfile`, using the **variant
+pattern** from [architecture.md §7.2](../architecture.md#72-variants--specializations-from-a-lagoon-parent).
+A combined specialization (`-persistent-drupal`) layers on the *first*
+specialization (`-drupal`), not on `-persistent`.
+
+### 2. Wire it in `docker-bake.hcl`
+
+```hcl
+target "service-X-persistent-drupal" {
+  inherits   = ["default"]
+  context    = "images/service-persistent-drupal"
+  dockerfile = "X.Dockerfile"
+  tags       = tags("service-X-persistent-drupal")
+  contexts   = {
+    "${LOCAL_REPO}/service-drupal": "target:service-X-drupal"
+  }
+}
+```
+
+Variant targets **only reference their direct parent**, not commons.
+**Exception:** if the Dockerfile has its own `FROM ${LOCAL_REPO}/commons AS commons`
+build stage (e.g. `solr-9-drupal` does this to use git/curl from
+commons), it must also list commons in `contexts`. See
+[architecture.md §7.3](../architecture.md#73-the-commons-as-build-stage-exception).
+
+Then add the target to the service group **and** the `default` group.
+
+### 3. Test + validate as in Recipe 1, step 4.
+
+---
+
+## Recipe 3 — Add a brand-new service with multiple variants
+
+Order of operations:
+
+1. Create all Dockerfiles in dependency order:
+   `service-X` → `service-X-drupal` → `service-X-persistent` → `service-X-persistent-drupal`.
+2. Add **all** targets to `docker-bake.hcl`. The base targets commons,
+   variants reference their parent. Add every target to a new (or
+   existing) service group **and** to `default`.
+3. Add compose entries + TESTING commands for every variant.
+4. `make build/service-X-persistent-drupal` (which transitively builds the rest).
+5. Validate every variant via the local compose loop in Recipe 1 step 4.
+6. Commit Dockerfiles + bake changes + helpers in a single PR.
+
+---
+
+## Recipe 4 — Test patterns by service type
+
+These are *patterns*. Always run them against the built image and adjust
+to real output before committing.
+
+**PHP (FPM on port 9000)** — needs a startup wait:
+```bash
+docker run --rm --net all-images_default jwilder/dockerize \
+  dockerize -wait tcp://php-X-Y-dev:9000 -timeout 1m
+docker compose exec -T php-X-Y-dev sh -c "php -v" | grep "X.Y"
+docker compose exec -T php-X-Y-dev sh -c "php -m" | grep "<extension>"
+```
+
+**Python / Node / Ruby (HTTP on port 3000)** — no wait needed:
+```bash
+docker compose exec -T <svc>-X-Y sh -c "<runtime> --version" | grep "X.Y"
+docker compose exec -T commons sh -c "curl <svc>-X-Y:3000/<endpoint>" | grep "<expected>"
+```
+
+**Databases (mariadb / mysql / postgres / mongo)**:
+```bash
+docker compose exec -T <svc>-X-Y sh -c "<client> --version" | grep "X.Y"
+docker compose exec -T <svc>-X-Y sh -c "<server-version-cmd>" | grep "X.Y"
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/SERVICE?service=<svc>-X-Y" | grep "SERVICE_HOST="
+```
+
+**Varnish**:
+```bash
+docker compose exec -T commons sh -c "curl -I varnish-X:8080" | grep -i "Varnish" | grep -i "X."
+docker compose exec -T varnish-X sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_bodyaccess.so
+docker compose exec -T varnish-X sh -c "ls -la /usr/lib/varnish/vmods" | grep libvmod_dynamic.so
+```
+
+**PHP dev vs prod environments** — keep separate compose entries:
+```yaml
+php-X-Y-dev:
+  environment:
+    - LAGOON_ENVIRONMENT_TYPE=development
+    - XDEBUG_ENABLE=true
+
+php-X-Y-prod:
+  environment:
+    - LAGOON_ENVIRONMENT_TYPE=production
+```
+
+Every new service should also have a `docker ps` startup check:
+```bash
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep <svc>-X-Y
+```
+
+---
+
+## Recipe 5 — Mark an image as End-of-Life
+
+After the standard OCI labels in the Dockerfile, add:
+
+```dockerfile
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/<replacement>"
+```
+
+**Replacement selection** (in priority order): longest remaining
+upstream support → latest LTS / stable → reasonable upgrade path. The
+replacement must already exist in this repo. Examples:
+
+| EOL image      | Suggested replacement |
+| -------------- | --------------------- |
+| `mariadb-10.6` | `mariadb-11.4`        |
+| `postgres-14`  | `postgres-17`         |
+| `php-8.2`      | `php-8.5`             |
+| `python-3.10`  | `python-3.14`         |
+
+Keep the image building and publishing — only add the labels. Trivy /
+Syft / Grype and the Lagoon platform consume them to warn users.
+
+---
+
+## Recipe 6 — Remove an EOL image (after ≥ 6 months)
+
+1. `rm images/<service>/<version>.Dockerfile`
+2. In `docker-bake.hcl`: delete the `target` block, remove the target
+   name from the service group, **and** remove it from the `default`
+   group.
+3. Remove the service entry from
+   [helpers/images-docker-compose.yml](../helpers/images-docker-compose.yml)
+   or [helpers/services-docker-compose.yml](../helpers/services-docker-compose.yml).
+4. Remove all related commands from the relevant
+   `helpers/TESTING_*_dockercompose.md`.
+5. Verify the cleanup:
+   ```bash
+   grep -r "<service>-<version>" . --exclude-dir=.git --exclude-dir=scans
+   make build-list | grep "<service>-<version>"   # should be empty
+   ```
+
+---
+
+## Critical gotchas
+
+- **Three bake edits, not one.** Adding a target without also adding it
+  to its service group **and** `default` means CI silently won't build
+  it. This is the most common mistake.
+- **Variants do not list commons in `contexts`.** Only first-tier
+  images do — unless the Dockerfile has an explicit
+  `FROM ${LOCAL_REPO}/commons AS commons` build stage.
+- **Combined specializations layer on the first specialization.**
+  `varnish-8-persistent-drupal` extends `varnish-8-drupal`, not
+  `varnish-8-persistent`.
+- **Target names use dashes; tags keep dots.** `php-8-3-fpm` (target)
+  vs `php-8.3-fpm` (tag).
+- **Always run every TESTING command against the actual built image
+  before committing.** Do not assume version strings — verify them
+  (e.g. `redis_version:7.2.6` vs `7.2.4` has caused CI failures).
+- **Local compose testing requires `sed 's/uselagoon/lagoon/g'`** so the
+  compose file resolves to your locally-built tags, not the published
+  ones.

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,509 @@
+# Lagoon Images — Architecture
+
+This document is the **reference description** of how the `lagoon-images`
+repository is structured: what it builds, how the build system is wired,
+how images relate to one another, and how they flow from source to
+published artifacts.
+
+It is intended for maintainers and reviewers who need to understand *why*
+the repo is shaped the way it is. For task-oriented "how do I add / remove
+/ test an image?" recipes, see [.github/copilot-instructions.md](.github/copilot-instructions.md).
+
+---
+
+## 1. Purpose & scope
+
+`lagoon-images` produces the **base container images** that
+[Lagoon](https://github.com/uselagoon/lagoon) uses to host Drupal, PHP and
+related workloads on Kubernetes. Every image in this repository is:
+
+- **Alpine-based** (directly or transitively, via `commons`).
+- **Built and published as multi-arch** (`linux/amd64` + `linux/arm64`) on
+  the `main` branch and on tagged releases.
+- **Composed of a small foundation image (`commons`) plus a layered tree
+  of service / variant images** that all reuse the same entrypoint and
+  utility scripts.
+
+The images themselves are consumed by Lagoon project repositories via
+their `docker-compose.yml` `image:` references — they are *base* images,
+not application images.
+
+---
+
+## 2. Repository layout
+
+```
+lagoon-images/
+├── architecture.md                     ← you are here
+├── docker-bake.hcl                     ← single source of truth for all build targets
+├── Makefile                            ← thin wrapper around `docker buildx bake`
+├── Jenkinsfile                         ← CI: build → test → publish
+├── README.md
+├── renovate.json                       ← upstream version bumps
+├── build.txt / scan.txt                ← generated cross-reference tables
+│
+├── docs/
+│   └── reviewing/
+│       └── PR_REVIEW_RUBRIC.md         ← PR review criteria
+│
+├── helpers/                            ← test harness consumed by Jenkins
+│   ├── images-docker-compose.yml       ← compose stack for "base image" tests
+│   ├── services-docker-compose.yml     ← compose stack for "service image" tests
+│   ├── TESTING_base_images_dockercompose.md
+│   └── TESTING_service_images_dockercompose.md
+│
+├── images/                             ← one folder per image family
+│   ├── commons/                        ← the foundation
+│   ├── nginx/        nginx-drupal/
+│   ├── php-fpm/      php-cli/    php-cli-drupal/
+│   ├── node/         node-builder/  node-cli/
+│   ├── mariadb/      mariadb-drupal/
+│   ├── mysql/        postgres/   postgres-drupal/
+│   ├── solr/         solr-drupal/
+│   ├── varnish/      varnish-drupal/   varnish-persistent/   varnish-persistent-drupal/
+│   ├── redis/        redis-persistent/   valkey/
+│   ├── rabbitmq/     rabbitmq-cluster/
+│   ├── opensearch/   mongo/
+│   └── python/       ruby/
+│
+├── build/                              ← empty marker files (build cache)
+└── scans/                              ← Syft / Grype output
+```
+
+Every `images/<family>/` folder contains either a single `Dockerfile`
+(for single-version images like `nginx`) or one `<version>.Dockerfile`
+per supported version (e.g. `8.3.Dockerfile`, `8.4.Dockerfile`).
+
+---
+
+## 3. The image hierarchy
+
+### 3.1 Naming convention
+
+```
+{service}-{version}[-variant][-specialization]
+```
+
+| Token            | Meaning                                                    | Examples                                  |
+| ---------------- | ---------------------------------------------------------- | ----------------------------------------- |
+| `service`        | Software being packaged                                    | `php`, `node`, `varnish`, `postgres`      |
+| `version`        | Major (or major.minor) upstream version                    | `8.3`, `22`, `8`, `17`                    |
+| `variant`        | Form factor of the same software                           | `fpm`, `cli`, `builder`, `persistent`     |
+| `specialization` | Workload-specific tuning (almost always Drupal)            | `drupal`                                  |
+
+Examples that exercise the full pattern:
+
+- `php-8.3-fpm` — service + version + variant
+- `php-8.3-cli-drupal` — service + version + variant + specialization
+- `varnish-8-persistent-drupal` — service + version + variant + specialization
+- `node-22-builder` — service + version + variant
+
+### 3.2 Dependency tiers
+
+Every image fits into one of four tiers:
+
+```mermaid
+flowchart TD
+    upstream["Upstream image<br/>(alpine, php-fpm, node, varnish, …)"]
+    commons["<b>commons</b><br/>Alpine + /lagoon/, ep, fix-permissions, tini"]
+    base["<b>Base service image</b><br/>e.g. nginx, php-8.3-fpm, node-22, varnish-8"]
+    variant["<b>Variant</b><br/>e.g. node-22-builder, php-8.3-cli, varnish-8-persistent"]
+    spec["<b>Specialization</b><br/>e.g. nginx-drupal, php-8.3-cli-drupal,<br/>varnish-8-persistent-drupal"]
+
+    upstream --> commons
+    upstream --> base
+    commons -.copies /lagoon, ep, fix-permissions.-> base
+    base --> variant
+    base --> spec
+    variant --> spec
+```
+
+Key rules:
+
+1. **Every image transitively depends on `commons`.** First-tier images
+   (those that build directly `FROM upstream:version`) pull commons in
+   as a *named build stage* and copy `/lagoon`, `/bin/ep` and
+   `/bin/fix-permissions` from it.
+2. **Variants and specializations build `FROM` their parent Lagoon
+   image**, not from upstream. They do *not* re-stage commons.
+3. **A combined specialization** (e.g. `varnish-8-persistent-drupal`)
+   chains from the most specific parent already produced (here:
+   `varnish-8-drupal`).
+
+### 3.3 A worked example: the `varnish-8` family
+
+```mermaid
+flowchart LR
+    upstream[varnish:8 upstream]
+    commons[commons]
+    v8[varnish-8]
+    v8d[varnish-8-drupal]
+    v8p[varnish-8-persistent]
+    v8pd[varnish-8-persistent-drupal]
+
+    commons -.commons stage.-> v8
+    upstream --> v8
+    v8 --> v8d
+    v8 --> v8p
+    v8d --> v8pd
+```
+
+- `varnish-8` adds Lagoon entrypoints and `/lagoon` tooling to upstream.
+- `varnish-8-drupal` layers in Drupal-specific VCL.
+- `varnish-8-persistent` swaps the cache backend to file-backed storage.
+- `varnish-8-persistent-drupal` combines both — and is layered on
+  `varnish-8-drupal` (the *first* specialization), not on
+  `varnish-8-persistent`.
+
+The same pattern is used across `node-*`, `php-*`, `redis-*`,
+`postgres-*`, `mariadb-*`, `solr-*`, etc.
+
+---
+
+## 4. The `commons` foundation
+
+`commons` is intentionally minimal. It provides:
+
+| Path                          | Purpose                                                        |
+| ----------------------------- | -------------------------------------------------------------- |
+| `/lagoon/entrypoints/`        | Numbered shell scripts run on container start                  |
+| `/lagoon/entrypoints.sh`      | Sources every file in `/lagoon/entrypoints/` alphabetically    |
+| `/lagoon/bin/cron`            | `go-crond` binary for in-container cron                        |
+| `/bin/ep`                     | `envplate` — environment variable templating in config files   |
+| `/bin/fix-permissions`        | Make a path writable by the running (often unknown) UID        |
+| `/bin/fix-dir-permissions`    | Directory-only variant                                          |
+| `/bin/docker-sleep`           | Default `CMD` for "do nothing" containers                      |
+| `/bin/wait-for`               | TCP wait helper                                                 |
+| `/bin/entrypoint-readiness`   | Readiness probe helper                                          |
+| `/sbin/tini`                  | PID 1 / signal handling                                         |
+
+The container `ENTRYPOINT` is always `tini → /lagoon/entrypoints.sh`.
+This means **every Lagoon image inherits the same boot sequence**, and a
+service image extends it simply by dropping a numbered script into
+`/lagoon/entrypoints/` (e.g. `10-php-fpm.sh`, `50-ssh-client.sh`).
+
+---
+
+## 5. The build system
+
+### 5.1 Architecture
+
+```mermaid
+flowchart TD
+    dev["Developer / CI"]
+    make["Makefile"]
+    bake["docker-bake.hcl"]
+    buildx["docker buildx<br/>(builder: ci-lagoon-images)"]
+    buildkit[BuildKit]
+    local["Local images<br/>${CI_BUILD_TAG}/*:latest"]
+    testlagoon["docker.io/testlagoon/*<br/>(branches & PRs)"]
+    uselagoon["docker.io/uselagoon/*<br/>(tagged releases)"]
+
+    dev --> make
+    make -- "renders args & calls" --> bake
+    bake -- "targets + contexts" --> buildx
+    buildx --> buildkit
+    buildkit --> local
+    buildkit -- "publish-testlagoon-images" --> testlagoon
+    buildkit -- "publish-uselagoon-images" --> uselagoon
+```
+
+### 5.2 `docker-bake.hcl` — the single source of truth
+
+`docker-bake.hcl` declares **every image, its dependencies, and its
+published tags**. There is no scripted build graph elsewhere; if it isn't
+in bake, it isn't built.
+
+It contains four kinds of declaration:
+
+**1. Variables** — knobs supplied by the Makefile / CI environment:
+
+| Variable              | Default              | Used for                                              |
+| --------------------- | -------------------- | ----------------------------------------------------- |
+| `LOCAL_REPO`          | `lagoon`             | Prefix used for inter-image `FROM`/`contexts` lookups |
+| `LOCAL_TAG`           | `latest`             | Tag for locally-built images                          |
+| `LAGOON_VERSION`      | `development`        | Embedded in image label and `/lagoon/version`         |
+| `PUSH_REPO`           | `ghcr.io/uselagoon`  | Registry prefix for `tags()`                          |
+| `PUSH_TAG`            | `latest`             | Primary published tag                                 |
+| `PUSH_TAG_ADDITIONAL` | `""`                 | Optional second tag (e.g. `latest` on a release)      |
+| `PLATFORMS`           | `linux/amd64`        | Comma-separated buildx platforms                      |
+| `NO_CACHE`            | `false`              | Force layer rebuilds                                  |
+
+**2. The `default` target** — inherited by every image target. It sets
+platforms, OCI labels, `no-cache`, and the build args
+(`LAGOON_VERSION`, `PUSH_REPO`, `PUSH_TAG`, `LOCAL_REPO`).
+
+**3. Per-image targets** — one per buildable image:
+
+```hcl
+target "php-8-3-fpm" {
+  inherits   = ["default"]
+  context    = "images/php-fpm"
+  dockerfile = "8.3.Dockerfile"
+  tags       = tags("php-8.3-fpm")
+  contexts   = {
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+}
+```
+
+Two naming details to keep straight:
+
+- **Target name** uses dashes (`php-8-3-fpm`) because HCL identifiers
+  cannot contain dots.
+- **Tag name** (passed to `tags()`) keeps the dotted form
+  (`php-8.3-fpm`) because that is the public image name.
+
+The `contexts` map is how dependencies are wired. The key is the name a
+child Dockerfile references in its `FROM ${LOCAL_REPO}/<name>` line, and
+the value is `target:<other-bake-target>`. BuildKit uses this to build
+the dependency first and pin the child to its locally-built tag instead
+of pulling from a registry.
+
+**4. Groups** — convenience aggregations:
+
+- `default` — every image in the repo.
+- One per service family (`php`, `node`, `varnish`, `postgres`, …).
+
+A new image must be added to its family group **and** to `default`,
+otherwise `make build` and CI will silently skip it.
+
+### 5.3 The `tags()` function
+
+```hcl
+function "tags" {
+  params = [image]
+  result = notequal(PUSH_TAG_ADDITIONAL, "")
+    ? ["${PUSH_REPO}/${image}:${PUSH_TAG}",
+       "${PUSH_REPO}/${image}:${PUSH_TAG_ADDITIONAL}"]
+    : ["${PUSH_REPO}/${image}:${PUSH_TAG}"]
+}
+```
+
+This is what produces `docker.io/testlagoon/nginx:my-branch` during a PR
+build and `docker.io/uselagoon/nginx:v2.20.0` + `…:latest` on a tagged
+release — the Makefile flips the variables, bake re-renders the tags.
+
+### 5.4 The Makefile
+
+The Makefile is intentionally thin — it only sets variables and calls
+`docker buildx bake`. The interesting recipes:
+
+| Target                          | Effect                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `make build`                    | Build all targets, load into local Docker (single platform)             |
+| `make build-bg`                 | Same as `build`, but no `--load` (used for multi-arch CI builds)        |
+| `make build/<image>`            | Build one target *and its parents* (dots map to dashes automatically)   |
+| `make build-list`               | Print every `build/<target>` recipe                                     |
+| `make build-tags`               | Print every published tag bake would produce                            |
+| `make scan-images`              | Run Syft + Grype over every produced tag, write to `scans/`             |
+| `make publish-testlagoon-images`| Push to `docker.io/testlagoon/<image>:${BRANCH_NAME}`                   |
+| `make publish-uselagoon-images` | Push to `docker.io/uselagoon/<image>:${LAGOON_VERSION}` + `:latest`     |
+| `make docker_buildx_create`     | Create the dedicated `ci-lagoon-images` buildx builder                  |
+
+Per-image build markers are written to `build/` so repeated invocations
+short-circuit; `make clean` removes them to force a rebuild.
+
+---
+
+## 6. CI / publishing flow
+
+```mermaid
+flowchart TD
+    pr["PR opened or branch pushed"]
+    j_env["env / clean cache"]
+    j_build["make build<br/>(single arch, local)"]
+    j_pubsingle["make publish-testlagoon-images<br/>BRANCH_NAME=&lt;branch&gt; (linux/amd64)"]
+    j_examples["clone uselagoon/lagoon-examples<br/>rewrite image refs to CI_BUILD_TAG"]
+    j_test["TESTING_base_images + TESTING_service_images<br/>+ yarn test:simple + yarn test:advanced"]
+    j_main{"branch == main<br/>or arm64-images?"}
+    j_arm["make build-bg PLATFORM_ARCH=linux/arm64"]
+    j_pubmulti["make publish-testlagoon-images<br/>PLATFORM_ARCH=linux/arm64,linux/amd64<br/>PUSH_TAG_ADDITIONAL=latest"]
+    j_tag{"buildingTag()?"}
+    j_pubrelease["make publish-uselagoon-images<br/>PUSH_TAG=&lt;version&gt; PUSH_TAG_ADDITIONAL=latest"]
+    done(["done"])
+
+    pr --> j_env --> j_build --> j_pubsingle --> j_examples --> j_test --> j_main
+    j_main -- yes --> j_arm --> j_pubmulti --> j_tag
+    j_main -- no --> j_tag
+    j_tag -- yes --> j_pubrelease --> done
+    j_tag -- no --> done
+```
+
+Notes on the pipeline ([Jenkinsfile](Jenkinsfile)):
+
+- **`CI_BUILD_TAG`** is derived from the branch + build number and used
+  as `LOCAL_REPO`, so concurrent CI runs cannot collide on local image
+  names.
+- **Tests run against the just-built local images**, not against
+  `uselagoon/*`. The test stage rewrites `uselagoon` to `${CI_BUILD_TAG}`
+  in every cloned compose / Dockerfile reference.
+- **Multi-arch (`linux/arm64`) is only built on `main` and tagged
+  releases.** PR builds are amd64-only to keep cycle time tractable.
+- **Tagged releases** are the only path to `docker.io/uselagoon/*`.
+
+---
+
+## 7. Dockerfile conventions
+
+### 7.1 First-tier images (`FROM upstream`)
+
+```dockerfile
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/commons AS commons
+FROM upstream:version
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+LABEL org.opencontainers.image.authors="The Lagoon Authors"
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/<family>/<file>"
+LABEL org.opencontainers.image.description="…"
+LABEL org.opencontainers.image.title="uselagoon/<image>"
+LABEL org.opencontainers.image.base.name="docker.io/upstream:version"
+
+ENV LAGOON=<service-name>
+
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/
+
+# … service-specific RUN, COPY, ENTRYPOINT overrides …
+```
+
+### 7.2 Variants / specializations (`FROM` a Lagoon parent)
+
+```dockerfile
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/varnish-8-drupal
+
+LABEL org.opencontainers.image.source="…"
+LABEL org.opencontainers.image.description="…"
+LABEL org.opencontainers.image.title="uselagoon/varnish-8-persistent-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/varnish-8-drupal"
+
+# … only the diff vs the parent …
+```
+
+The `ARG LOCAL_REPO` + `FROM ${LOCAL_REPO:-lagoon}/...` pattern is what
+allows the same Dockerfile to resolve to:
+
+- `lagoon/varnish-8-drupal` during a developer's local `make build`,
+- `lagoon<branch-buildnumber>/varnish-8-drupal` during CI, and
+- `docker.io/uselagoon/varnish-8-drupal` when consumed downstream.
+
+### 7.3 The "commons-as-build-stage" exception
+
+A handful of images (e.g. `solr-9-drupal`) need commons during build
+even though they themselves derive from a Lagoon parent — typically to
+use `git`/`curl` from commons to fetch supplemental assets. These
+declare commons as a *named stage* and **must also list commons in their
+bake `contexts`**:
+
+```hcl
+target "solr-9-drupal" {
+  contexts = {
+    "${LOCAL_REPO}/solr-9":  "target:solr-9",
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+}
+```
+
+---
+
+## 8. Testing
+
+### 8.1 Two test surfaces
+
+| Surface           | Compose file                        | Test commands                                |
+| ----------------- | ----------------------------------- | -------------------------------------------- |
+| Base images       | `helpers/images-docker-compose.yml` | `helpers/TESTING_base_images_dockercompose.md`     |
+| Service images    | `helpers/services-docker-compose.yml` | `helpers/TESTING_service_images_dockercompose.md` |
+
+"Base images" cover language runtimes and HTTP servers (`commons`,
+`php-fpm`, `node`, `python`, `ruby`, `nginx`, `varnish`, …). "Service
+images" cover stateful services (`mariadb`, `mysql`, `postgres`,
+`redis`, `valkey`, `rabbitmq`, `opensearch`, `mongo`, `solr`).
+
+### 8.2 What the test markdown actually is
+
+The `TESTING_*_dockercompose.md` files are **executable specifications**:
+they are parsed by `yarn test` (in the `lagoon-examples` repo) which
+extracts each fenced shell block and runs it. The first matching grep
+pattern decides pass/fail.
+
+### 8.3 How CI runs them
+
+1. Jenkins clones [`uselagoon/lagoon-examples`](https://github.com/uselagoon/lagoon-examples).
+2. It copies `helpers/*-docker-compose.yml` and `helpers/TESTING_*.md`
+   into `tests/all-images/`.
+3. It rewrites `uselagoon` → `${CI_BUILD_TAG}` so the tests run against
+   the locally-built images.
+4. It runs four suites in order: base images, service images, simple
+   Drupal, advanced Drupal.
+
+### 8.4 Local equivalent
+
+```bash
+cp helpers/images-docker-compose.yml docker-compose.yml
+sed -i '' 's/uselagoon/lagoon/g' docker-compose.yml   # macOS sed
+docker compose up -d <service>
+# run individual command from TESTING_*.md
+docker compose down && rm docker-compose.yml
+```
+
+---
+
+## 9. Security & supply-chain scanning
+
+`make scan-images` runs after every published build:
+
+- **Syft** — SBOM per tag → `scans/<image>.syft.txt`
+- **Grype** — vulnerability scan per tag → `scans/<image>.grype.txt`
+
+Outputs are committed in CI to feed both the Lagoon platform's
+deprecation/EOL warning system and OpenSSF Scorecard reporting.
+
+The repository carries an [OpenSSF Best Practices badge](https://www.bestpractices.dev/projects/11411)
+and an OpenSSF Scorecard, both surfaced in the [README](README.md).
+
+---
+
+## 10. Image lifecycle
+
+```mermaid
+flowchart LR
+    new["New version<br/>(target + group + Dockerfile + tests)"]
+    active["Active<br/>built, tested, published"]
+    eol["EOL<br/>labels:<br/>sh.lagoon.image.deprecated.status<br/>sh.lagoon.image.deprecated.suggested"]
+    removed["Removed<br/>(after ≥ 6 months)"]
+
+    new --> active --> eol --> removed
+```
+
+Two distinct phases:
+
+1. **EOL marking.** The image keeps building and publishing but carries
+   `sh.lagoon.image.deprecated.status="endoflife"` and a
+   `sh.lagoon.image.deprecated.suggested` label pointing at the
+   recommended successor. Scanners and the Lagoon platform surface this
+   to users.
+2. **Removal.** After at least six months of EOL warnings, the image is
+   deleted from `images/`, its bake target and group memberships are
+   removed, and its compose entry + test commands are stripped from
+   `helpers/`.
+
+For the precise mechanics of both phases, see the EOL section in
+[.github/copilot-instructions.md](.github/copilot-instructions.md).
+
+---
+
+## 11. Where to look next
+
+| If you want to…                                | Read                                                       |
+| ---------------------------------------------- | ---------------------------------------------------------- |
+| Add, remove, or test an image                  | [.github/copilot-instructions.md](.github/copilot-instructions.md) |
+| Review a PR                                    | [docs/reviewing/PR_REVIEW_RUBRIC.md](docs/reviewing/PR_REVIEW_RUBRIC.md) |
+| Understand build orchestration                 | [docker-bake.hcl](docker-bake.hcl), [Makefile](Makefile)   |
+| Understand the CI flow                         | [Jenkinsfile](Jenkinsfile)                                 |
+| Understand the entrypoint / commons utilities  | [images/commons/](images/commons)                          |
+| Run or extend the test suites                  | [helpers/](helpers)                                        |

--- a/architecture.md
+++ b/architecture.md
@@ -475,7 +475,7 @@ flowchart LR
     new["New version<br/>(target + group + Dockerfile + tests)"]
     active["Active<br/>built, tested, published"]
     eol["EOL<br/>labels:<br/>sh.lagoon.image.deprecated.status<br/>sh.lagoon.image.deprecated.suggested"]
-    removed["Removed<br/>(after ≥ 6 months)"]
+    removed["Removed<br/>(after ≥ 1 release)"]
 
     new --> active --> eol --> removed
 ```
@@ -487,12 +487,16 @@ Two distinct phases:
    `sh.lagoon.image.deprecated.suggested` label pointing at the
    recommended successor. Scanners and the Lagoon platform surface this
    to users.
-2. **Removal.** After at least six months of EOL warnings, the image is
+2. **Removal.** After at least one release with EOL warnings, the image is
    deleted from `images/`, its bake target and group memberships are
    removed, and its compose entry + test commands are stripped from
    `helpers/`.
+3. **Lagoon Reporting.** Lagoon Builds will always mark these images as
+   deprecated for as long as the image remains published and available.
+   In some faster-moving images, the replacement image may also have been
+   marked deprecated, but can't be resolved without republishing.
 
-For the precise mechanics of both phases, see the EOL section in
+For the precise mechanics of these phases, see the EOL section in
 [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
 ---

--- a/docs/reviewing/PR_REVIEW_RUBRIC.md
+++ b/docs/reviewing/PR_REVIEW_RUBRIC.md
@@ -1,0 +1,258 @@
+# Lagoon Images – PR Review Rubric for AI Agents
+
+## Before You Start (Required)
+
+1. Identify affected image(s) by directory (`images/php-fpm/`, `images/nginx/`, etc.)
+2. Classify the change type:
+   - Base image change (`commons`, `nginx`, `php-fpm`)
+   - Variant image change (`nginx-drupal`, `php-cli-drupal`)
+   - Helper script change (`helpers/`)
+   - Build system change (`docker-bake.hcl`, `Makefile`)
+   - Documentation-only
+3. If multiple image families are affected, note cross-image impact in the summary. Do **not** repeat the same comment across multiple files.
+
+---
+
+## 1. Base Image Version Pinning
+
+**Checks:**
+- [ ] `FROM` uses a fully-qualified tag (e.g. `alpine:3.19`, not `alpine:latest`)
+- [ ] Major version bumps are intentional
+- [ ] Digest pinning used for shared base images
+
+**Comment templates:**
+
+| Condition | Comment |
+|-----------|---------|
+| Unpinned tag | `Base image is not version-pinned. Pin to a specific version to ensure reproducible builds.` |
+| Major version bump | `This bumps the base image major version. Confirm compatibility with downstream Lagoon services.` |
+
+One comment per Dockerfile maximum. Digest pinning is encouraged for shared base images but not required elsewhere.
+
+## 2. Layer construction and determinism
+
+**Explicit checks**
+
+Copilot must check:
+
+RUN steps:
+
+No interactive commands
+
+No time-dependent behavior
+
+Package installs:
+
+Use --no-cache (apk)
+
+Clean up package lists
+
+No redundant layers adding then removing files
+
+Comment rules
+
+If temp artifacts remain:
+
+“Temporary build artifacts are left in the final image. Clean up in the same layer to reduce image size.”
+
+If layering is inefficient:
+
+“Multiple RUN layers perform related setup. Consider consolidating to reduce image layers.”
+
+No style commentary. Size and determinism only.
+
+## 3. Helper scripts (helpers/, shared scripts)
+
+**Explicit checks**
+
+If a helper script changes, Copilot must verify:
+
+It is used by multiple images
+
+It remains POSIX-compatible
+
+It fails fast (set -e or equivalent)
+
+Error output is meaningful
+
+Comment rules
+
+If helper script behavior changes:
+
+“This helper script is shared across multiple images. Confirm downstream impact and update relevant images if required.”
+
+If error handling weakens:
+
+“Helper scripts should fail fast with clear error output to avoid silent image misbuilds.”
+
+Copilot must not suggest refactors unless behavior is broken.
+
+## 4. Security posture (image-specific, not generic)
+
+**Explicit checks**
+
+Copilot must flag:
+
+curl | sh without checksum verification
+
+Downloaded binaries without integrity checks
+
+Build tools present in final runtime images
+
+Root user usage in runtime images (when avoidable)
+
+Comment rules
+
+External downloads:
+
+“External download lacks integrity verification. Add checksum validation to reduce supply-chain risk.”
+
+Runtime as root:
+
+“Image runs as root. If intended for runtime use, consider a non-root user unless explicitly required.”
+
+Copilot must not recommend security theatre. Only concrete risks.
+
+## 5. Image intent and audience clarity
+
+**Explicit checks**
+
+The canonical "header" of a Lagoon Dockerfile is its OCI label block. Verify it includes:
+
+- `org.opencontainers.image.source` — link to the file on GitHub
+- `org.opencontainers.image.description` — one-line statement of purpose / audience (build vs runtime, what workload)
+- `org.opencontainers.image.title` — `uselagoon/<image>` form
+- `org.opencontainers.image.base.name` — what this image extends
+
+Non-obvious `RUN` steps must carry an inline comment.
+
+**Comment templates:**
+
+| Condition | Comment |
+|-----------|---------|
+| Missing / vague description label | `OCI description label does not state image purpose or audience. Update to clarify intended use.` |
+| Non-obvious build logic | `This step is non-obvious. Add a brief comment explaining why it is required.` |
+
+One comment max per file.
+
+## 6. Cross-Image Consistency
+
+**Checks:**
+- [ ] `ENV` variable naming follows established patterns
+- [ ] All four `org.opencontainers.image.*` labels listed in §5 are present
+- [ ] Directory structure aligns with similar images (`images/<family>/<version>.Dockerfile`)
+- [ ] Common utilities copied from `commons` in the standard way (see [architecture.md §7.1](../../architecture.md#71-first-tier-images-from-upstream))
+- [ ] **Target name uses dashes; published tag keeps dots** (e.g. `php-8-3-fpm` target → `php-8.3-fpm` tag)
+- [ ] First-tier Dockerfiles use `ARG LOCAL_REPO` + `FROM ${LOCAL_REPO:-lagoon}/commons AS commons`; variants use `FROM ${LOCAL_REPO:-lagoon}/<parent>`
+
+**Comment template:**
+
+```
+This image diverges from conventions used in similar Lagoon images. See architecture.md §7 for the expected pattern.
+```
+
+Reference existing repo patterns only. Do not invent new conventions.
+
+## 7. Build wiring and test coverage
+
+This is the highest-frequency source of CI failures in this repo. All four checks below must pass for any new image, version, or variant.
+
+**Checks:**
+- [ ] `docker-bake.hcl` has a `target` block for the image
+- [ ] The target name is added to its **service-specific group** (e.g. `group "php"`)
+- [ ] The target name is also added to **`group "default"`**
+- [ ] The target's `contexts` map is correct:
+  - First-tier image → references `${LOCAL_REPO}/commons: target:commons`
+  - Variant / specialization → references its **direct parent only**, not commons
+  - Exception: a Dockerfile that declares its own `FROM ${LOCAL_REPO}/commons AS commons` build stage must also list commons in `contexts` (see [architecture.md §7.3](../../architecture.md#73-the-commons-as-build-stage-exception))
+- [ ] Combined specializations layer on the **first** specialization, not on a sibling variant (e.g. `varnish-8-persistent-drupal` extends `varnish-8-drupal`, not `varnish-8-persistent`)
+- [ ] New image has a service block in `helpers/images-docker-compose.yml` or `helpers/services-docker-compose.yml`
+- [ ] New image has matching test commands in the corresponding `helpers/TESTING_*_dockercompose.md`
+
+**Comment templates:**
+
+| Condition | Comment |
+|-----------|---------|
+| Target missing from `default` or service group | `Target is defined but not added to group "default" (and/or its service group). CI will silently skip it.` |
+| Variant lists commons in `contexts` | `Variant images should reference only their direct parent in \`contexts\`. Remove the commons entry unless this Dockerfile has an explicit \`FROM commons AS commons\` stage.` |
+| First-tier image missing commons context | `First-tier image is missing \`${LOCAL_REPO}/commons: target:commons\` in its bake \`contexts\`.` |
+| No test coverage | `New image has no compose entry or TESTING_*.md commands. Add coverage in helpers/.` |
+
+Do not speculate about test frameworks or suggest new testing approaches.
+
+## 8. Documentation
+
+**Checks:**
+- [ ] [README.md](../../README.md) updated when image behaviour, supported tags, or consumer-facing variants change
+- [ ] [.github/copilot-instructions.md](../../.github/copilot-instructions.md) updated when a recipe / workflow changes (e.g. new gotcha, new test pattern)
+- [ ] [architecture.md](../../architecture.md) updated when something *structural* changes (new image tier, new build variable, new pipeline stage, new convention)
+
+**Comment template:**
+
+```
+Documentation does not reflect this change. Update README / copilot-instructions / architecture as appropriate.
+```
+
+## 9. Lifecycle and backward compatibility
+
+The image lifecycle is: **active → EOL-labelled → removed (after ≥ 6 months)**. See [architecture.md §10](../../architecture.md#10-image-lifecycle).
+
+**Checks:**
+- [ ] No image removed without prior EOL labelling and a deprecation window
+- [ ] No published tag removed without an EOL marker on the image first
+- [ ] No default behaviour or `ENV` changed without a note in the PR description
+- [ ] No changes that break existing consumers without a clear upgrade path
+
+**Comment template:**
+
+```
+This change alters existing image behaviour. Confirm backward compatibility or document the breaking change and upgrade path.
+```
+
+Do not block internal refactors that do not affect external behaviour.
+
+## 10. End-of-life labelling
+
+Applies to PRs that mark an image as EOL or update an existing EOL marker. The full procedure is [Recipe 5 in copilot-instructions](../../.github/copilot-instructions.md#recipe-5--mark-an-image-as-end-of-life).
+
+**Checks:**
+- [ ] Both labels present, in the standard form:
+  ```dockerfile
+  LABEL sh.lagoon.image.deprecated.status="endoflife"
+  LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/<replacement>"
+  ```
+- [ ] The suggested replacement **already exists in this repo** as a built image
+- [ ] The replacement is the latest stable / longest-supported equivalent (not an arbitrary newer version)
+- [ ] The image continues to build and publish — only the labels are added, nothing is removed yet
+
+**Comment templates:**
+
+| Condition | Comment |
+|-----------|---------|
+| Suggested replacement missing or not built here | `Suggested replacement image is not built by this repo. Point to an image that exists in docker-bake.hcl.` |
+| Image gutted instead of labelled | `EOL marking should only add the two deprecation labels. Image must keep building and publishing for the deprecation window.` |
+
+---
+
+## Review Output Format
+
+Every review **must** use this exact structure:
+
+```markdown
+## Summary
+- **Images affected:** [list affected image directories]
+- **Risk level:** low | medium | high
+- **Backward compatible:** yes | no | n/a
+
+## Blocking Issues
+[Issues that break builds, introduce security risks, or break backward compatibility.]
+[If none: "No blocking issues."]
+
+## Non-Blocking Suggestions
+[Grouped, concise suggestions. Omit section if none.]
+```
+
+**Rules:**
+- No praise or positive commentary
+- No filler text or restatement of the diff
+- No repeating the same comment across multiple files


### PR DESCRIPTION
This pull request introduces comprehensive documentation improvements for AI agent workflows and PR review processes in the Lagoon base images repository. The changes provide detailed, task-focused instructions for both contributors and AI reviewers, aiming to standardize and clarify image addition, variant creation, EOL handling, and review expectations. The most important changes are grouped below:

**AI Agent Workflow & Task Instructions**

* Added a new `.github/copilot-instructions.md` file that gives step-by-step recipes for common contributor tasks (adding new versions, variants, services, marking/removing EOL images), including critical gotchas and test validation patterns. This document is highly prescriptive and references architecture docs for rationale.

**AI PR Review Rubric & Review Process**

* Introduced `docs/reviewing/PR_REVIEW_RUBRIC.md`, a detailed rubric for AI agents reviewing PRs. It covers checks for version pinning, build determinism, helper scripts, security, image intent, cross-image consistency, build wiring, documentation, lifecycle, and EOL labelling. The rubric includes explicit checklists, comment templates, and a required review output format.

**Documentation Consistency & Cross-referencing**

* Both new documents cross-reference each other and the core `architecture.md`, ensuring contributors and reviewers are aligned on conventions and expectations.

**CI Reliability & Error Prevention**

* The instructions and rubric emphasize common causes of CI failure (such as missing group wiring or test coverage) and prescribe explicit validation steps to catch these before merging.

**Image Lifecycle & EOL Handling**

* Clearly documents the procedure for marking images as end-of-life and the required deprecation window before removal, with standardized label usage and replacement selection rules.