### PR TITLE
Build: update base images to Alpine 3.23

### DIFF
--- a/images/commons/Dockerfile
+++ b/images/commons/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/amazeeio/go-crond:25.10.0 AS go-crond
 FROM ghcr.io/amazeeio/envplate:25.10.0 AS envplate
-FROM alpine:3.22.2
+FROM alpine:3.23.0
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/commons/Dockerfile"
 LABEL org.opencontainers.image.description="Base image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/commons"
-LABEL org.opencontainers.image.base.name="docker.io/alpine:3.22"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.23"
 
 ENV LAGOON=commons
 

--- a/images/mongo/4.Dockerfile
+++ b/images/mongo/4.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM alpine:3.22.2
+FROM alpine:3.23.0
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mongo/4.Dockerfile"
 LABEL org.opencontainers.image.description="MongoDB 4 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/mongo-4"
-LABEL org.opencontainers.image.base.name="docker.io/alpine:3.22"
+LABEL org.opencontainers.image.base.name="docker.io/alpine:3.23"
 
 ENV LAGOON=mongo
 

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.8-r0 \
+        mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client~=11.4 \
+        mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node-cli/22.Dockerfile
+++ b/images/node-cli/22.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.8-r0 \
+        mariadb-client~=11.4 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node-cli/24.Dockerfile
+++ b/images/node-cli/24.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client~=11.4 \
+        mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node-cli/24.Dockerfile
+++ b/images/node-cli/24.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash \
         findutils \
         git \
         gzip  \
-        mariadb-client=11.4.8-r0 \
+        mariadb-client~=11.4 \
         mariadb-connector-c \
         mongodb-tools \
         openssh-client \

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM node:20.20-alpine3.22
+FROM node:20.20-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/20.Dockerfile"
 LABEL org.opencontainers.image.description="Node.js 20 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/node-20"
-LABEL org.opencontainers.image.base.name="docker.io/node:20-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/node:20-alpine3.23"
 
 ENV LAGOON=node
 

--- a/images/node/22.Dockerfile
+++ b/images/node/22.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM node:22.22-alpine3.22
+FROM node:22.22-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/22.Dockerfile"
 LABEL org.opencontainers.image.description="Node.js 22 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/node-22"
-LABEL org.opencontainers.image.base.name="docker.io/node:22-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/node:22-alpine3.23"
 
 ENV LAGOON=node
 

--- a/images/node/24.Dockerfile
+++ b/images/node/24.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM node:24.13-alpine3.22
+FROM node:24.13-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/24.Dockerfile"
 LABEL org.opencontainers.image.description="Node.js 24 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/node-24"
-LABEL org.opencontainers.image.base.name="docker.io/node:24-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/node:24-alpine3.23"
 
 ENV LAGOON=node
 

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache bash \
         mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs=~22 \
+        nodejs=~24 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.1.Dockerfile
+++ b/images/php-cli/8.1.Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache bash \
         mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs=~24 \
+        nodejs=~22 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.2.Dockerfile
+++ b/images/php-cli/8.2.Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache bash \
         mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs=~22 \
+        nodejs=~24 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.3.Dockerfile
+++ b/images/php-cli/8.3.Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache bash \
         mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs=~22 \
+        nodejs=~24 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-cli/8.4.Dockerfile
+++ b/images/php-cli/8.4.Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache bash \
         mariadb-client=~11.4 \
         mariadb-connector-c \
         mongodb-tools \
-        nodejs=~22 \
+        nodejs=~24 \
         npm \
         openssh-client \
         openssh-sftp-server \

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -5,12 +5,13 @@ FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.7
 
-FROM php:8.1.34-fpm-alpine3.23
+# Held at alpine3.22 until EOL
+FROM php:8.1.34-fpm-alpine3.22
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.1.Dockerfile"
 LABEL org.opencontainers.image.description="PHP 8.1 FPM image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/php-8.1-fpm"
-LABEL org.opencontainers.image.base.name="docker.io/php:8.1-fpm-alpine3.23"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.1-fpm-alpine3.22"
 
 # End-of-life deprecation labels
 LABEL sh.lagoon.image.deprecated.status="endoflife"

--- a/images/php-fpm/8.1.Dockerfile
+++ b/images/php-fpm/8.1.Dockerfile
@@ -5,12 +5,12 @@ FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.7
 
-FROM php:8.1.34-fpm-alpine3.22
+FROM php:8.1.34-fpm-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.1.Dockerfile"
 LABEL org.opencontainers.image.description="PHP 8.1 FPM image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/php-8.1-fpm"
-LABEL org.opencontainers.image.base.name="docker.io/php:8.1-fpm-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.1-fpm-alpine3.23"
 
 # End-of-life deprecation labels
 LABEL sh.lagoon.image.deprecated.status="endoflife"

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -5,12 +5,12 @@ FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.7
 
-FROM php:8.2.30-fpm-alpine3.22
+FROM php:8.2.30-fpm-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.2.Dockerfile"
 LABEL org.opencontainers.image.description="PHP 8.2 FPM image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/php-8.2-fpm"
-LABEL org.opencontainers.image.base.name="docker.io/php:8.2-fpm-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.2-fpm-alpine3.23"
 
 ENV LAGOON=php
 

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -5,12 +5,12 @@ FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.7
 
-FROM php:8.3.30-fpm-alpine3.22
+FROM php:8.3.30-fpm-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.3.Dockerfile"
 LABEL org.opencontainers.image.description="PHP 8.3 FPM image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/php-8.3-fpm"
-LABEL org.opencontainers.image.base.name="docker.io/php:8.3-fpm-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.3-fpm-alpine3.23"
 
 ENV LAGOON=php
 

--- a/images/php-fpm/8.4.Dockerfile
+++ b/images/php-fpm/8.4.Dockerfile
@@ -5,12 +5,12 @@ FROM composer:latest AS healthcheckbuilder
 
 RUN composer create-project --no-dev amazeeio/healthz-php /healthz-php v0.0.7
 
-FROM php:8.4.17-fpm-alpine3.22
+FROM php:8.4.17-fpm-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.4.Dockerfile"
 LABEL org.opencontainers.image.description="PHP 8.4 FPM image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/php-8.4-fpm"
-LABEL org.opencontainers.image.base.name="docker.io/php:8.4-fpm-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/php:8.4-fpm-alpine3.23"
 
 ENV LAGOON=php
 

--- a/images/postgres/14.Dockerfile
+++ b/images/postgres/14.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM postgres:14.20-alpine3.22
+FROM postgres:14.20-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/14.Dockerfile"
 LABEL org.opencontainers.image.description="PostgreSQL 14 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/postgres-14"
-LABEL org.opencontainers.image.base.name="docker.io/postgres:14-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:14-alpine3.23"
 
 ENV LAGOON=postgres
 

--- a/images/postgres/15.Dockerfile
+++ b/images/postgres/15.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM postgres:15.15-alpine3.22
+FROM postgres:15.15-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/15.Dockerfile"
 LABEL org.opencontainers.image.description="PostgreSQL 15 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/postgres-15"
-LABEL org.opencontainers.image.base.name="docker.io/postgres:15-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:15-alpine3.23"
 
 ENV LAGOON=postgres
 

--- a/images/postgres/16.Dockerfile
+++ b/images/postgres/16.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM postgres:16.11-alpine3.22
+FROM postgres:16.11-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/16.Dockerfile"
 LABEL org.opencontainers.image.description="PostgreSQL 16 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/postgres-16"
-LABEL org.opencontainers.image.base.name="docker.io/postgres:16-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:16-alpine3.23"
 
 ENV LAGOON=postgres
 

--- a/images/postgres/17.Dockerfile
+++ b/images/postgres/17.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM postgres:17.7-alpine3.22
+FROM postgres:17.7-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/17.Dockerfile"
 LABEL org.opencontainers.image.description="PostgreSQL 17 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/postgres-17"
-LABEL org.opencontainers.image.base.name="docker.io/postgres:17-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:17-alpine3.23"
 
 ENV LAGOON=postgres
 

--- a/images/python/3.10.Dockerfile
+++ b/images/python/3.10.Dockerfile
@@ -1,12 +1,12 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 
-FROM python:3.10.19-alpine3.22
+FROM python:3.10.19-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.10.Dockerfile"
 LABEL org.opencontainers.image.description="Python 3.10 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/python-3.10"
-LABEL org.opencontainers.image.base.name="docker.io/python:3.10-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.10-alpine3.23"
 
 ENV LAGOON=python
 

--- a/images/python/3.11.Dockerfile
+++ b/images/python/3.11.Dockerfile
@@ -1,12 +1,12 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 
-FROM python:3.11.14-alpine3.22
+FROM python:3.11.14-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.11.Dockerfile"
 LABEL org.opencontainers.image.description="Python 3.11 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/python-3.11"
-LABEL org.opencontainers.image.base.name="docker.io/python:3.11-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.11-alpine3.23"
 
 ENV LAGOON=python
 

--- a/images/python/3.12.Dockerfile
+++ b/images/python/3.12.Dockerfile
@@ -1,12 +1,12 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 
-FROM python:3.12.12-alpine3.22
+FROM python:3.12.12-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.12.Dockerfile"
 LABEL org.opencontainers.image.description="Python 3.12 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/python-3.12"
-LABEL org.opencontainers.image.base.name="docker.io/python:3.12-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.12-alpine3.23"
 
 ENV LAGOON=python
 

--- a/images/python/3.13.Dockerfile
+++ b/images/python/3.13.Dockerfile
@@ -1,12 +1,12 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 
-FROM python:3.13.11-alpine3.22
+FROM python:3.13.11-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.13.Dockerfile"
 LABEL org.opencontainers.image.description="Python 3.13 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/python-3.13"
-LABEL org.opencontainers.image.base.name="docker.io/python:3.13-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.13-alpine3.23"
 
 ENV LAGOON=python
 

--- a/images/python/3.14.Dockerfile
+++ b/images/python/3.14.Dockerfile
@@ -1,12 +1,12 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 
-FROM python:3.14.2-alpine3.22
+FROM python:3.14.2-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.14.Dockerfile"
 LABEL org.opencontainers.image.description="Python 3.14 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/python-3.14"
-LABEL org.opencontainers.image.base.name="docker.io/python:3.14-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/python:3.14-alpine3.23"
 
 ENV LAGOON=python
 

--- a/images/redis/8.Dockerfile
+++ b/images/redis/8.Dockerfile
@@ -5,7 +5,7 @@ FROM redis:8.4.0-alpine3.22
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile"
 LABEL org.opencontainers.image.description="Redis 8 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/redis-8"
-LABEL org.opencontainers.image.base.name="docker.io/redis:8-alpine3.21"
+LABEL org.opencontainers.image.base.name="docker.io/redis:8-alpine3.22"
 
 ENV LAGOON=redis
 

--- a/images/ruby/3.2.Dockerfile
+++ b/images/ruby/3.2.Dockerfile
@@ -1,12 +1,12 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 
-FROM ruby:3.2.9-alpine3.22
+FROM ruby:3.2.10-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.2.Dockerfile"
 LABEL org.opencontainers.image.description="Ruby 3.2 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/ruby-3.2"
-LABEL org.opencontainers.image.base.name="docker.io/ruby:3.2-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/ruby:3.2-alpine3.23"
 
 ENV LAGOON=ruby
 

--- a/images/ruby/3.3.Dockerfile
+++ b/images/ruby/3.3.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM ruby:3.3.10-alpine3.22
+FROM ruby:3.3.10-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.3.Dockerfile"
 LABEL org.opencontainers.image.description="Ruby 3.3 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/ruby-3.3"
-LABEL org.opencontainers.image.base.name="docker.io/ruby:3.3-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/ruby:3.3-alpine3.23"
 
 ENV LAGOON=ruby
 

--- a/images/ruby/3.4.Dockerfile
+++ b/images/ruby/3.4.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM ruby:3.4.8-alpine3.22
+FROM ruby:3.4.8-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.4.Dockerfile"
 LABEL org.opencontainers.image.description="Ruby 3.4 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/ruby-3.4"
-LABEL org.opencontainers.image.base.name="docker.io/ruby:3.4-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/ruby:3.4-alpine3.23"
 
 ENV LAGOON=ruby
 

--- a/images/ruby/4.0.Dockerfile
+++ b/images/ruby/4.0.Dockerfile
@@ -1,6 +1,6 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM ruby:4.0.0-alpine3.23
+FROM ruby:4.0.1-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/4.0.Dockerfile"
 LABEL org.opencontainers.image.description="Ruby 4.0 image optimised for running in Lagoon in production and locally"

--- a/images/valkey/8.Dockerfile
+++ b/images/valkey/8.Dockerfile
@@ -1,6 +1,6 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM valkey/valkey:8.1.4-alpine3.22
+FROM valkey/valkey:8.1.5-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/valkey/8.Dockerfile"
 LABEL org.opencontainers.image.description="Valkey 8 image optimised for running in Lagoon in production and locally"

--- a/images/valkey/9.Dockerfile
+++ b/images/valkey/9.Dockerfile
@@ -1,6 +1,6 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM valkey/valkey:9.0.0-alpine3.22
+FROM valkey/valkey:9.0.1-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/valkey/9.Dockerfile"
 LABEL org.opencontainers.image.description="Valkey 9 image optimised for running in Lagoon in production and locally"


### PR DESCRIPTION
This pull request updates the Lagoon Docker images to use Alpine Linux 3.23 as the base image for most services, replacing the previous Alpine 3.22 version. It also updates certain package and dependency versions to ensure compatibility with the new base image.

**Base Image Upgrades:**

* Updated the base image from Alpine 3.22 to Alpine 3.23 in most images.
* Held the Redis 8 image to Alpine 3.22 until an update is released
* Held the PHP-FPM 8.1 image at Alpine 3.22 due to EOL.

**Dependency and Package Version Updates:**

* Updated `nodejs` dependency from `~22` to `~24` in PHP8.2+ images for compatibility with the new Alpine base..
* Pinned `mariadb-client` dependency in Node images from a fixed version (`11.4.8-r0`) to a version range (`~11.4`) for better compatibility with Alpine 3.23.
