### PR TITLE
fix: php 8.5 images not tagged with PUSH_TAG_ADDITIONAL

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -644,7 +644,7 @@ target "php-8-5-fpm" {
     "${LOCAL_REPO}/commons": "target:commons"
   }
   dockerfile = "8.5.Dockerfile"
-  tags = ["${PUSH_REPO}/php-8.5-fpm:${PUSH_TAG}"]
+  tags = tags("php-8.5-fpm")
 }
 
 target "php-8-5-cli" {
@@ -654,7 +654,7 @@ target "php-8-5-cli" {
     "${LOCAL_REPO}/php-8.5-fpm": "target:php-8-5-fpm"
   }
   dockerfile = "8.5.Dockerfile"
-  tags = ["${PUSH_REPO}/php-8.5-cli:${PUSH_TAG}"]
+  tags = tags("php-8.5-cli")
 }
 
 target "php-8-5-cli-drupal" {
@@ -664,7 +664,7 @@ target "php-8-5-cli-drupal" {
     "${LOCAL_REPO}/php-8.5-cli": "target:php-8-5-cli"
   }
   dockerfile = "8.5.Dockerfile"
-  tags = ["${PUSH_REPO}/php-8.5-cli-drupal:${PUSH_TAG}"]
+  tags = tags("php-8.5-cli-drupal")
 }
 
 target "postgres-14" {


### PR DESCRIPTION
All PHP 8.5 images are missing the `latest` tag in Docker Hub https://hub.docker.com/r/uselagoon/php-8.4-cli-drupal/tags.

It looks like a minor change is missing from two PRs done in parallel: [add php 8.5 images](https://github.com/uselagoon/lagoon-images/pull/1501) and [change how tags work](https://github.com/uselagoon/lagoon-images/pull/1507).

This PR fixes PHP 8.5 image tags to use the new `tags()` method which should bring back `latest` tag.