### PR TITLE
Update Redis image to 8.6.0-alpine3.23

### DIFF
--- a/images/redis/8.Dockerfile
+++ b/images/redis/8.Dockerfile
@@ -1,11 +1,11 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM redis:8.4.0-alpine3.22
+FROM redis:8.6.0-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile"
 LABEL org.opencontainers.image.description="Redis 8 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/redis-8"
-LABEL org.opencontainers.image.base.name="docker.io/redis:8-alpine3.22"
+LABEL org.opencontainers.image.base.name="docker.io/redis:8.6.0-alpine3.23"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION


### PR DESCRIPTION
Upgrade the Redis image to version 8.6.0-alpine3.23 for improved performance and compatibility.