### PR TITLE
Fix Makefile MACHINE auto-detection on Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ BRANCH_NAME :=
 
 PUBLISH_PLATFORM_ARCH := linux/amd64,linux/arm64
 
+MACHINE ?= $(shell uname -m)
+
 ifeq ($(MACHINE), arm64)
 	PLATFORM_ARCH ?= linux/arm64
 else

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ PUBLISH_PLATFORM_ARCH := linux/amd64,linux/arm64
 
 MACHINE ?= $(shell uname -m)
 
-ifeq ($(MACHINE), arm64)
+ifeq ($(filter $(MACHINE), arm64 aarch64), $(MACHINE))
 	PLATFORM_ARCH ?= linux/arm64
 else
 	PLATFORM_ARCH ?= linux/amd64


### PR DESCRIPTION
MACHINE was only checked but never auto-set, causing PLATFORM_ARCH to always default to linux/amd64 on arm64 Macs unless MACHINE=arm64 was passed manually. Default MACHINE from uname -m so native builds work out of the box.