### PR TITLE
Correct the user agent for Site24x7 and extend Fast Health

### DIFF
--- a/images/nginx/helpers/90_healthz_fast_check.conf.disabled
+++ b/images/nginx/helpers/90_healthz_fast_check.conf.disabled
@@ -1,6 +1,6 @@
 set $fhcc none;
 
-if ( $http_user_agent ~* "StatusCake|Pingdom|Site25x7|Uptime|nagios" ) {
+if ( $http_user_agent ~* "StatusCake|Pingdom|Site24x7|Uptime|nagios" ) {
   set $fhcc "A";
 }
 

--- a/images/nginx/helpers/90_healthz_fast_check.conf.disabled
+++ b/images/nginx/helpers/90_healthz_fast_check.conf.disabled
@@ -1,6 +1,7 @@
 set $fhcc none;
 
-if ( $http_user_agent ~* "StatusCake|Pingdom|Site24x7|Uptime|nagios" ) {
+# Case insensitive matching on user agent.
+if ( $http_user_agent ~* "StatusCake|Pingdom|Site24x7|Uptime|nagios|monitoring" ) {
   set $fhcc "A";
 }
 


### PR DESCRIPTION
This triggered my OCD.

Example user agent:

```
Firefox: Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1 Site24x7
```

Fixes https://github.com/uselagoon/lagoon-images/issues/710