### PR TITLE
feat: add solr-10 image (non-Drupal)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -115,6 +115,7 @@ group "default" {
     "ruby-4-0",
     "solr-9",
     "solr-9-drupal",
+    "solr-10",
     "valkey-8",
     "valkey-9",
     "varnish-6",
@@ -264,6 +265,7 @@ group "solr" {
     "commons", 
     "solr-9",
     "solr-9-drupal",
+    "solr-10",
   ]
 }
 
@@ -871,6 +873,17 @@ target "solr-9-drupal" {
   dockerfile = "9.Dockerfile"
   tags = tags("solr-9-drupal")
 }
+
+target "solr-10" {
+  inherits = ["default"]
+  context = "images/solr"
+  contexts = {
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+  dockerfile = "10.Dockerfile"
+  tags = tags("solr-10")
+}
+
 target "valkey-8" {
   inherits = ["default"]
   context = "images/valkey"

--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -39,6 +39,7 @@ docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp:/
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-7:6379 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-8:6379 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://solr-9:8983 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://solr-10:8983 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://valkey-8:6379 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://valkey-9:6379 -timeout 1m
 ```
@@ -67,6 +68,7 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-7
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep solr-9
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep solr-10
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep valkey-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep valkey-9
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep varnish-6
@@ -328,6 +330,19 @@ docker compose exec -T solr-9 sh -c "cat /var/solr/data/mycore/conf/solrconfig.x
 # solr-9 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr?service=solr-9" | grep "SERVICE_HOST=solr-9"
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr?service=solr-9" | grep "LAGOON_TEST_VAR=all-images"
+
+# solr-10 should have a "mycore" Solr core
+docker compose exec -T commons sh -c "curl solr-10:8983/solr/admin/cores?action=STATUS\&core=mycore"
+
+# solr-10 should be able to reload "mycore" Solr core
+docker compose exec -T commons sh -c "curl solr-10:8983/solr/admin/cores?action=RELOAD\&core=mycore"
+
+# solr-10 should have solr 10 solrconfig in "mycore" core
+docker compose exec -T solr-10 sh -c "cat /var/solr/data/mycore/conf/solrconfig.xml" | grep luceneMatchVersion | grep 10.
+
+# solr-10 should be able to read/write data
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr?service=solr-10" | grep "SERVICE_HOST=solr-10"
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/solr?service=solr-10" | grep "LAGOON_TEST_VAR=all-images"
 
 # valkey-8 should be running Valkey v8 server and Redis compatible
 docker compose exec -T valkey-8 sh -c "valkey-server --version" | grep v=8.

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -136,6 +136,12 @@ services:
       - "8983"
     user: solr
 
+  solr-10:
+    image: uselagoon/solr-10:latest
+    ports:
+      - "8983"
+    user: solr
+
   valkey-8:
     image: uselagoon/valkey-8:latest
     ports:

--- a/images/solr/10.Dockerfile
+++ b/images/solr/10.Dockerfile
@@ -1,0 +1,77 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/commons AS commons
+FROM solr:10.0.0
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/solr/10.Dockerfile"
+LABEL org.opencontainers.image.description="Solr 10 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/solr-10"
+LABEL org.opencontainers.image.base.name="docker.io/solr:10"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+ENV LAGOON=solr
+
+ENV SOLR_DATA_HOME=/var/solr
+ENV SOLR_LOGS_DIR=/opt/solr/server/logs
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /home/.bashrc /home/.bashrc
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+# we need root for the fix-permissions to work
+USER root
+
+RUN <<EOF
+echo 'Acquire::http::Timeout "60";' >> /etc/apt/apt.conf.d/99timeouts
+echo 'Acquire::ftp::Timeout "60";' >> /etc/apt/apt.conf.d/99timeouts
+echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99timeouts
+EOF
+
+RUN apt-get -y update \
+    && apt-get -y install \
+        busybox \
+        curl \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini
+
+RUN mkdir -p /var/solr /opt/solr/server/logs /opt/solr/server/solr
+RUN fix-permissions /var/solr \
+    && chown solr:solr /var/solr /opt/solr/server/logs /opt/solr/server/solr \
+    && fix-permissions /opt/solr/server/logs \
+    && fix-permissions /opt/solr/server/solr
+
+COPY solr-recreate.sh /opt/solr/docker/scripts/solr-recreate
+COPY solr-foreground.sh /opt/solr/docker/scripts/solr-foreground
+RUN chmod 775 /opt/solr/docker/scripts/solr-recreate /opt/solr/docker/scripts/solr-foreground
+
+# solr really doesn't like to be run as root, so we define the default user again
+USER solr
+
+ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+
+# Define Volume so locally we get persistent cores
+VOLUME /var/solr
+
+# Define provided solr-docker entrypoint to append
+ENV APPEND_NATIVE_ENTRYPOINT=/opt/solr/docker/scripts/docker-entrypoint.sh
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+
+# solr-precreate creates the core on disk then calls solr-foreground.
+# solr-foreground injects --user-managed unless SOLR_CLOUD_MODE=true,
+# keeping standalone mode despite Solr 10 defaulting to SolrCloud.
+CMD ["solr-precreate", "mycore"]

--- a/images/solr/10.Dockerfile
+++ b/images/solr/10.Dockerfile
@@ -63,6 +63,10 @@ USER solr
 
 ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 
+# JDK21+ have new XML parsing limits that cause Solr to fail when indexing large documents. These options disable those limits.
+# REF https://www.drupal.org/project/search_api_solr/issues/3577485
+ENV JDK_JAVA_OPTIONS="-Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0"
+
 # Define Volume so locally we get persistent cores
 VOLUME /var/solr
 

--- a/images/solr/solr-foreground.sh
+++ b/images/solr/solr-foreground.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run the initdb, then start solr in the foreground.
+# Lagoon override: in Solr 10 the default mode is SolrCloud; inject
+# --user-managed to keep standalone mode unless SOLR_CLOUD_MODE=true.
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+# Could set env-variables for solr-fg
+source run-initdb
+
+if [[ "${SOLR_CLOUD_MODE:-}" != "true" ]] && [[ "$*" != *"--user-managed"* ]]; then
+    set -- --user-managed "$@"
+fi
+
+exec solr-fg "$@"


### PR DESCRIPTION
- images/solr/10.Dockerfile: Based on solr:10.0.0 with Lagoon commons integration, tini entrypoint, and CMD matching solr-9 pattern
- images/solr/solr-foreground.sh: Override solr-foreground to inject --user-managed flag, keeping standalone mode despite Solr 10 defaulting to SolrCloud
- docker-bake.hcl: Add solr-10 target to default and solr groups
- Test infrastructure: Add solr-10 to services-docker-compose.yml and TESTING_service_images_dockercompose.md

Note: solr-10-drupal is intentionally excluded; Drupal does not yet have official Solr 10 support.