### PR TITLE
Remove Trivy results display from scanning scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ openshift
 /helpers/node_modules
 /helpers/yarn.lock
 /helpers/package.json
+helpers/docker-compose.override.yml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,9 +136,8 @@ pipeline {
       }
       steps {
         sh script: 'make scan-images', label: "perform scan routines"
-        sh script:  'find ./scans/*trivy* -type f | xargs tail -n +1', label: "Show Trivy vulnerability scan results"
-        sh script:  'find ./scans/*grype* -type f | xargs tail -n +1', label: "Show Grype vulnerability scan results"
         sh script:  'find ./scans/*syft* -type f | xargs tail -n +1', label: "Show Syft SBOM results"
+        sh script:  'find ./scans/*grype* -type f | xargs tail -n +1', label: "Show Grype vulnerability scan results"
       }
     }
   }

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ scan-images:
 	rm -f ./scans/*.txt
 	@for tag in $(shell $(MAKE) build-tags); do \
 			tag_name=$$(echo $$tag | sed 's|.*/\([^:]*\):.*|\1|'); \
-			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/root/.cache/ aquasec/trivy image --timeout 5m0s $$tag > ./scans/$$tag_name.trivy.txt ; \
 			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock anchore/syft $$tag > ./scans/$$tag_name.syft.txt ; \
 			docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/Library/Caches:/var/lib/grype/db anchore/grype --add-cpes-if-none $$tag > ./scans/$$tag_name.grype.txt ; \
 			echo $$tag ; \


### PR DESCRIPTION
This pull request updates the image scanning routines in the CI pipeline by removing the use of Trivy for vulnerability scanning and adjusting the order in which scan results are displayed. The main focus is on streamlining the scan process to use Grype and Syft only.

**CI/CD Pipeline and Image Scanning Changes:**

* Removed the Trivy vulnerability scanning step from both the `Makefile` and the Jenkins pipeline, so images are now only scanned with Syft and Grype. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L125) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L139-R140)
* Adjusted the order of displaying scan results in the Jenkins pipeline to show Syft SBOM results before Grype vulnerability scan results.