### PR TITLE
Removes latest releasever strategy from dnf updates to fix breaking b…

### DIFF
--- a/images/opensearch/2.Dockerfile
+++ b/images/opensearch/2.Dockerfile
@@ -19,7 +19,7 @@ COPY --from=commons /home /home
 
 USER root
 
-RUN dnf update --releasever=latest -y \
+RUN dnf update -y \
     && dnf install -y \
         findutils \
         rsync \

--- a/images/opensearch/3.Dockerfile
+++ b/images/opensearch/3.Dockerfile
@@ -19,7 +19,7 @@ COPY --from=commons /home /home
 
 USER root
 
-RUN dnf update --releasever=latest -y \
+RUN dnf update -y \
     && dnf install -y \
         findutils \
         rsync \


### PR DESCRIPTION
This pull request makes a minor update to the `dnf update` command in both the `2.Dockerfile` and `3.Dockerfile` for the OpenSearch images. The `--releasever=latest` flag has been removed from the update command, likely to improve compatibility or reliability of the image builds. No other changes were made.
