### PR TITLE
Update Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,20 @@
 
 ## When reviewing a PR
 
-Use [docs/reviewing/PR_REVIEW_RUBRIC.md](../docs/reviewing/PR_REVIEW_RUBRIC.md).
+### Instruction source for CI Copilot reviews
+
+For guidance that must be enforced on every automated PR review, place it in
+`.github/instructions/*.instructions.md`.
+
+Keep this file as task-focused guidance and workflow recipes. Linked docs
+such as `architecture.md` and `docs/reviewing/PR_REVIEW_RUBRIC.md` are
+reference material. Use `.github/instructions/pr-review.instructions.md` as
+the canonical machine-consumed PR review policy.
+
+Use [`.github/instructions/pr-review.instructions.md`](instructions/pr-review.instructions.md)
+for enforceable review checks, and
+[docs/reviewing/PR_REVIEW_RUBRIC.md](../docs/reviewing/PR_REVIEW_RUBRIC.md)
+for explanatory context.
 Focus on:
 
 1. **Correctness** — reproducible builds, explicit version pins.
@@ -141,6 +154,11 @@ Then add the target to the service group **and** the `default` group.
 
 ### 3. Test + validate as in Recipe 1, step 4.
 
+For variants, the normal expectation is **targeted validation** rather
+than re-running the full base-image test suite: startup check, version
+check, and assertions specific to the variant behavior (for example
+Drupal VCL or persistent cache settings).
+
 ---
 
 ## Recipe 3 — Add a brand-new service with multiple variants
@@ -154,7 +172,8 @@ Order of operations:
    existing) service group **and** to `default`.
 3. Add compose entries + TESTING commands for every variant.
 4. `make build/service-X-persistent-drupal` (which transitively builds the rest).
-5. Validate every variant via the local compose loop in Recipe 1 step 4.
+5. Fully validate the **base** image via the local compose loop in
+  Recipe 1 step 4, then run targeted smoke checks for each variant.
 6. Commit Dockerfiles + bake changes + helpers in a single PR.
 
 ---
@@ -163,6 +182,14 @@ Order of operations:
 
 These are *patterns*. Always run them against the built image and adjust
 to real output before committing.
+
+Default testing depth:
+
+- Run the full verification set on the base image for the service.
+- For variants, run focused checks that prove the variant delta
+  (plus startup and version checks).
+- Only run full suites on every variant when the change is broad enough
+  to affect all variants.
 
 **PHP (FPM on port 9000)** — needs a startup wait:
 ```bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -263,7 +263,7 @@ Syft / Grype and the Lagoon platform consume them to warn users.
 
 ---
 
-## Recipe 6 — Remove an EOL image (after ≥ 6 months)
+## Recipe 6 — Remove an EOL image (typically after 1-2 releases)
 
 1. `rm images/<service>/<version>.Dockerfile`
 2. In `docker-bake.hcl`: delete the `target` block, remove the target

--- a/.github/instructions/pr-review.instructions.md
+++ b/.github/instructions/pr-review.instructions.md
@@ -1,0 +1,213 @@
+# Lagoon Images - Copilot PR Review Instructions
+
+This is the canonical, machine-consumed policy for automated Copilot PR
+reviews in this repository.
+
+If this file conflicts with prose guidance elsewhere, this file wins for
+automation behavior.
+
+## Before You Start (Required)
+
+1. Identify affected image(s) by directory (`images/php-fpm/`, `images/nginx/`, etc.)
+2. Classify the change type:
+   - Base image change (`commons`, `nginx`, `php-fpm`)
+   - Variant image change (`nginx-drupal`, `php-cli-drupal`)
+   - Helper script change (`helpers/`)
+   - Build system change (`docker-bake.hcl`, `Makefile`)
+   - Documentation-only
+3. If multiple image families are affected, note cross-image impact in the summary.
+4. Do not repeat the same comment across multiple files.
+
+## 1. Base Image Version Pinning
+
+Checks:
+
+- `FROM` uses a fully-qualified tag (e.g. `alpine:3.19`, not `alpine:latest`)
+- Existing version Dockerfiles only receive minor/patch updates (as applicable)
+- Major version updates are introduced as new image/version Dockerfiles, not by mutating existing version Dockerfiles
+
+Comment templates:
+
+- Unpinned tag: `Base image is not version-pinned. Pin to a specific version to ensure reproducible builds.`
+- Major version bump in existing Dockerfile: `Major version bumps should be introduced via a new image/version Dockerfile. Keep existing version Dockerfiles on minor/patch updates only.`
+
+One comment per Dockerfile maximum.
+
+## 2. Layer Construction and Determinism
+
+Checks:
+
+- No interactive commands in `RUN` steps
+- No time-dependent behavior
+- Package installs use `--no-cache` (apk)
+- Package lists are cleaned up
+- No redundant add/remove layering patterns
+
+Comment templates:
+
+- Temp artifacts remain: `Temporary build artifacts are left in the final image. Clean up in the same layer to reduce image size.`
+- Inefficient layering: `Multiple RUN layers perform related setup. Consider consolidating to reduce image layers.`
+
+No style commentary. Focus on determinism and image size.
+
+## 3. Helper Scripts
+
+If a helper script changes, verify:
+
+- It is used by multiple images
+- It remains POSIX-compatible
+- It fails fast (`set -e` or equivalent)
+- Error output is meaningful
+
+Comment templates:
+
+- Shared behavior change: `This helper script is shared across multiple images. Confirm downstream impact and update relevant images if required.`
+- Error handling weakens: `Helper scripts should fail fast with clear error output to avoid silent image misbuilds.`
+
+Do not suggest refactors unless behavior is broken.
+
+## 4. Security Posture
+
+Flag concrete risks:
+
+- `curl | sh` without checksum verification
+- Downloaded binaries without integrity checks
+- Build tools present in final runtime images
+- Runtime images using root when avoidable
+
+Comment templates:
+
+- External download risk: `External download lacks integrity verification. Add checksum validation to reduce supply-chain risk.`
+- Runtime root user: `Image runs as root. If intended for runtime use, consider a non-root user unless explicitly required.`
+
+No generic security theater.
+
+## 5. Image Intent and Audience Clarity
+
+Verify OCI labels include:
+
+- `org.opencontainers.image.source`
+- `org.opencontainers.image.description`
+- `org.opencontainers.image.title`
+- `org.opencontainers.image.base.name`
+
+Non-obvious `RUN` steps must carry a brief inline comment.
+
+Comment templates:
+
+- Missing/vague description: `OCI description label does not state image purpose or audience. Update to clarify intended use.`
+- Non-obvious logic: `This step is non-obvious. Add a brief comment explaining why it is required.`
+
+One comment max per file.
+
+## 6. Cross-Image Consistency
+
+Checks:
+
+- `ENV` naming follows established patterns
+- All four OCI labels from section 5 are present
+- Directory structure matches established image families
+- Utilities from `commons` are copied using established pattern
+- Target name uses dashes; published tag keeps dots
+- First-tier images use `ARG LOCAL_REPO` + `FROM ${LOCAL_REPO:-lagoon}/commons AS commons`
+- Variants use `FROM ${LOCAL_REPO:-lagoon}/<parent>`
+
+Comment template:
+
+`This image diverges from conventions used in similar Lagoon images. See architecture.md section 7 for the expected pattern.`
+
+Reference existing repository conventions only.
+
+## 7. Build Wiring and Test Coverage
+
+For any new image, version, or variant, verify all of:
+
+- `docker-bake.hcl` has a target block
+- Target is in the service-specific group
+- Target is in `group "default"`
+- `contexts` map is correct for first-tier vs variant
+- Combined specializations layer on the first specialization
+- Compose service entry exists in `helpers/images-docker-compose.yml` or `helpers/services-docker-compose.yml`
+- Matching commands exist in corresponding `helpers/TESTING_*_dockercompose.md`
+
+Comment templates:
+
+- Missing group wiring: `Target is defined but not added to group "default" (and/or its service group). CI will silently skip it.`
+- Variant incorrectly includes commons in contexts: `Variant images should reference only their direct parent in contexts. Remove the commons entry unless this Dockerfile has an explicit FROM commons AS commons stage.`
+- First-tier missing commons context: `First-tier image is missing ${LOCAL_REPO}/commons: target:commons in its bake contexts.`
+- Missing compose/testing coverage: `New image has no compose entry or TESTING_*.md commands. Add coverage in helpers/.`
+
+## 8. Documentation
+
+Check for needed updates to:
+
+- `README.md` for consumer-visible behavior/tag changes
+- `.github/copilot-instructions.md` for workflow/recipe changes
+- `architecture.md` for structural convention changes
+
+Comment template:
+
+`Documentation does not reflect this change. Update README / copilot-instructions / architecture as appropriate.`
+
+## 9. Lifecycle and Backward Compatibility
+
+Checks:
+
+- No image removed without prior EOL labeling and deprecation window
+- No published tag removed without EOL marker first
+- No default behavior or `ENV` changed without PR note
+- No breaking changes without clear upgrade path
+
+Comment template:
+
+`This change alters existing image behaviour. Confirm backward compatibility or document the breaking change and upgrade path.`
+
+Do not block internal refactors that do not affect external behavior.
+
+## 10. End-of-Life Labeling
+
+For EOL changes, verify:
+
+- Both labels are present exactly as expected
+- Suggested replacement exists in this repository build graph
+- Replacement is latest stable / longest-supported equivalent
+- Image still builds and publishes during deprecation window
+
+Comment templates:
+
+- Missing/nonexistent replacement: `Suggested replacement image is not built by this repo. Point to an image that exists in docker-bake.hcl.`
+- Image gutted instead of labeled: `EOL marking should only add the two deprecation labels. Image must keep building and publishing for the deprecation window.`
+
+## Review Output Format (Required)
+
+Always use this exact structure:
+
+```markdown
+## Summary
+- **Images affected:** [list affected image directories]
+- **Risk level:** low | medium | high
+- **Backward compatible:** yes | no | n/a
+
+## Blocking Issues
+[Issues that break builds, introduce security risks, or break backward compatibility.]
+[If none: "No blocking issues."]
+
+## Non-Blocking Suggestions
+[Grouped, concise suggestions. Omit section if none.]
+```
+
+Rules:
+
+- No praise or positive commentary
+- No filler text or restatement of the diff
+- No duplicate comments across files
+
+## References
+
+Use these as supporting references when available:
+
+- `docs/reviewing/PR_REVIEW_RUBRIC.md`
+- `architecture.md`
+- `.github/copilot-instructions.md`
+
+If references are unavailable at runtime, continue with this file's rules.

--- a/architecture.md
+++ b/architecture.md
@@ -44,7 +44,7 @@ lagoon-images/
 │
 ├── docs/
 │   └── reviewing/
-│       └── PR_REVIEW_RUBRIC.md         ← PR review criteria
+│       └── PR_REVIEW_RUBRIC.md         ← PR review context/rationale
 │
 ├── helpers/                            ← test harness consumed by Jenkins
 │   ├── images-docker-compose.yml       ← compose stack for "base image" tests
@@ -475,7 +475,7 @@ flowchart LR
     new["New version<br/>(target + group + Dockerfile + tests)"]
     active["Active<br/>built, tested, published"]
     eol["EOL<br/>labels:<br/>sh.lagoon.image.deprecated.status<br/>sh.lagoon.image.deprecated.suggested"]
-    removed["Removed<br/>(after ≥ 1 release)"]
+  removed["Removed<br/>(after ≥ 6 months)"]
 
     new --> active --> eol --> removed
 ```
@@ -487,7 +487,7 @@ Two distinct phases:
    `sh.lagoon.image.deprecated.suggested` label pointing at the
    recommended successor. Scanners and the Lagoon platform surface this
    to users.
-2. **Removal.** After at least one release with EOL warnings, the image is
+2. **Removal.** After at least 6 months with EOL warnings, the image is
    deleted from `images/`, its bake target and group memberships are
    removed, and its compose entry + test commands are stripped from
    `helpers/`.
@@ -506,7 +506,7 @@ For the precise mechanics of these phases, see the EOL section in
 | If you want to…                                | Read                                                       |
 | ---------------------------------------------- | ---------------------------------------------------------- |
 | Add, remove, or test an image                  | [.github/copilot-instructions.md](.github/copilot-instructions.md) |
-| Review a PR                                    | [docs/reviewing/PR_REVIEW_RUBRIC.md](docs/reviewing/PR_REVIEW_RUBRIC.md) |
+| Review a PR                                    | [.github/instructions/pr-review.instructions.md](.github/instructions/pr-review.instructions.md) |
 | Understand build orchestration                 | [docker-bake.hcl](docker-bake.hcl), [Makefile](Makefile)   |
 | Understand the CI flow                         | [Jenkinsfile](Jenkinsfile)                                 |
 | Understand the entrypoint / commons utilities  | [images/commons/](images/commons)                          |

--- a/architecture.md
+++ b/architecture.md
@@ -475,7 +475,7 @@ flowchart LR
     new["New version<br/>(target + group + Dockerfile + tests)"]
     active["Active<br/>built, tested, published"]
     eol["EOL<br/>labels:<br/>sh.lagoon.image.deprecated.status<br/>sh.lagoon.image.deprecated.suggested"]
-  removed["Removed<br/>(after ≥ 6 months)"]
+  removed["Removed<br/>(typically after 1-2 releases)"]
 
     new --> active --> eol --> removed
 ```
@@ -487,7 +487,7 @@ Two distinct phases:
    `sh.lagoon.image.deprecated.suggested` label pointing at the
    recommended successor. Scanners and the Lagoon platform surface this
    to users.
-2. **Removal.** After at least 6 months with EOL warnings, the image is
+2. **Removal.** Typically after 1-2 releases with EOL warnings, the image is
    deleted from `images/`, its bake target and group memberships are
    removed, and its compose entry + test commands are stripped from
    `helpers/`.

--- a/docs/reviewing/PR_REVIEW_RUBRIC.md
+++ b/docs/reviewing/PR_REVIEW_RUBRIC.md
@@ -1,258 +1,57 @@
-# Lagoon Images – PR Review Rubric for AI Agents
+# Lagoon Images - PR Review Rubric (Explanatory Context)
 
-## Before You Start (Required)
+This document explains the review policy and why it exists.
 
-1. Identify affected image(s) by directory (`images/php-fpm/`, `images/nginx/`, etc.)
-2. Classify the change type:
-   - Base image change (`commons`, `nginx`, `php-fpm`)
-   - Variant image change (`nginx-drupal`, `php-cli-drupal`)
-   - Helper script change (`helpers/`)
-   - Build system change (`docker-bake.hcl`, `Makefile`)
-   - Documentation-only
-3. If multiple image families are affected, note cross-image impact in the summary. Do **not** repeat the same comment across multiple files.
+For automated Copilot enforcement rules, use:
 
----
+- `.github/instructions/pr-review.instructions.md` (canonical machine-consumed policy)
 
-## 1. Base Image Version Pinning
+## Why This File Exists
 
-**Checks:**
-- [ ] `FROM` uses a fully-qualified tag (e.g. `alpine:3.19`, not `alpine:latest`)
-- [ ] Major version bumps are intentional
-- [ ] Digest pinning used for shared base images
+- Human maintainers need rationale and intent, not only strict rule text.
+- The repository needs a stable place to describe review philosophy,
+  priorities, and maintenance expectations.
+- Automation reliability requires machine-consumable rules in
+  `.github/instructions/*.instructions.md`.
 
-**Comment templates:**
+## Source of Truth Model
 
-| Condition | Comment |
-|-----------|---------|
-| Unpinned tag | `Base image is not version-pinned. Pin to a specific version to ensure reproducible builds.` |
-| Major version bump | `This bumps the base image major version. Confirm compatibility with downstream Lagoon services.` |
+- Canonical automation rules live in `.github/instructions/pr-review.instructions.md`.
+- This file is explanatory context and should remain aligned with that file.
+- `architecture.md` and `.github/copilot-instructions.md` provide supporting
+  structure and workflow guidance.
 
-One comment per Dockerfile maximum. Digest pinning is encouraged for shared base images but not required elsewhere.
+## Review Priorities (Context)
 
-## 2. Layer construction and determinism
+In descending practical impact for this repository:
 
-**Explicit checks**
+1. Build wiring correctness (`docker-bake.hcl` targets + service group + `default` group)
+2. Test coverage wiring in `helpers/` compose/testing files
+3. Deterministic and secure Dockerfile changes
+4. Backward compatibility and lifecycle handling
+5. Documentation updates for consumer-visible or structural changes
 
-Copilot must check:
+## Expected Reviewer Behavior (Context)
 
-RUN steps:
+- Keep findings concrete and actionable.
+- Avoid duplicate comments across files for the same root cause.
+- Prefer repository conventions over generic best-practice advice.
+- Flag concrete risks, not speculative concerns.
 
-No interactive commands
+## When to Update What
 
-No time-dependent behavior
+- Update `.github/instructions/pr-review.instructions.md` when changing
+  mandatory automated review behavior.
+- Update this file when changing explanatory guidance, rationale, or review
+  operating model.
+- Update `.github/copilot-instructions.md` when workflow recipes or maintainer
+  instructions change.
+- Update `architecture.md` when structural repository conventions change.
 
-Package installs:
+## Practical Maintenance Rule
 
-Use --no-cache (apk)
+If this file and `.github/instructions/pr-review.instructions.md` disagree,
+automation follows `.github/instructions/pr-review.instructions.md`.
 
-Clean up package lists
-
-No redundant layers adding then removing files
-
-Comment rules
-
-If temp artifacts remain:
-
-“Temporary build artifacts are left in the final image. Clean up in the same layer to reduce image size.”
-
-If layering is inefficient:
-
-“Multiple RUN layers perform related setup. Consider consolidating to reduce image layers.”
-
-No style commentary. Size and determinism only.
-
-## 3. Helper scripts (helpers/, shared scripts)
-
-**Explicit checks**
-
-If a helper script changes, Copilot must verify:
-
-It is used by multiple images
-
-It remains POSIX-compatible
-
-It fails fast (set -e or equivalent)
-
-Error output is meaningful
-
-Comment rules
-
-If helper script behavior changes:
-
-“This helper script is shared across multiple images. Confirm downstream impact and update relevant images if required.”
-
-If error handling weakens:
-
-“Helper scripts should fail fast with clear error output to avoid silent image misbuilds.”
-
-Copilot must not suggest refactors unless behavior is broken.
-
-## 4. Security posture (image-specific, not generic)
-
-**Explicit checks**
-
-Copilot must flag:
-
-curl | sh without checksum verification
-
-Downloaded binaries without integrity checks
-
-Build tools present in final runtime images
-
-Root user usage in runtime images (when avoidable)
-
-Comment rules
-
-External downloads:
-
-“External download lacks integrity verification. Add checksum validation to reduce supply-chain risk.”
-
-Runtime as root:
-
-“Image runs as root. If intended for runtime use, consider a non-root user unless explicitly required.”
-
-Copilot must not recommend security theatre. Only concrete risks.
-
-## 5. Image intent and audience clarity
-
-**Explicit checks**
-
-The canonical "header" of a Lagoon Dockerfile is its OCI label block. Verify it includes:
-
-- `org.opencontainers.image.source` — link to the file on GitHub
-- `org.opencontainers.image.description` — one-line statement of purpose / audience (build vs runtime, what workload)
-- `org.opencontainers.image.title` — `uselagoon/<image>` form
-- `org.opencontainers.image.base.name` — what this image extends
-
-Non-obvious `RUN` steps must carry an inline comment.
-
-**Comment templates:**
-
-| Condition | Comment |
-|-----------|---------|
-| Missing / vague description label | `OCI description label does not state image purpose or audience. Update to clarify intended use.` |
-| Non-obvious build logic | `This step is non-obvious. Add a brief comment explaining why it is required.` |
-
-One comment max per file.
-
-## 6. Cross-Image Consistency
-
-**Checks:**
-- [ ] `ENV` variable naming follows established patterns
-- [ ] All four `org.opencontainers.image.*` labels listed in §5 are present
-- [ ] Directory structure aligns with similar images (`images/<family>/<version>.Dockerfile`)
-- [ ] Common utilities copied from `commons` in the standard way (see [architecture.md §7.1](../../architecture.md#71-first-tier-images-from-upstream))
-- [ ] **Target name uses dashes; published tag keeps dots** (e.g. `php-8-3-fpm` target → `php-8.3-fpm` tag)
-- [ ] First-tier Dockerfiles use `ARG LOCAL_REPO` + `FROM ${LOCAL_REPO:-lagoon}/commons AS commons`; variants use `FROM ${LOCAL_REPO:-lagoon}/<parent>`
-
-**Comment template:**
-
-```
-This image diverges from conventions used in similar Lagoon images. See architecture.md §7 for the expected pattern.
-```
-
-Reference existing repo patterns only. Do not invent new conventions.
-
-## 7. Build wiring and test coverage
-
-This is the highest-frequency source of CI failures in this repo. All four checks below must pass for any new image, version, or variant.
-
-**Checks:**
-- [ ] `docker-bake.hcl` has a `target` block for the image
-- [ ] The target name is added to its **service-specific group** (e.g. `group "php"`)
-- [ ] The target name is also added to **`group "default"`**
-- [ ] The target's `contexts` map is correct:
-  - First-tier image → references `${LOCAL_REPO}/commons: target:commons`
-  - Variant / specialization → references its **direct parent only**, not commons
-  - Exception: a Dockerfile that declares its own `FROM ${LOCAL_REPO}/commons AS commons` build stage must also list commons in `contexts` (see [architecture.md §7.3](../../architecture.md#73-the-commons-as-build-stage-exception))
-- [ ] Combined specializations layer on the **first** specialization, not on a sibling variant (e.g. `varnish-8-persistent-drupal` extends `varnish-8-drupal`, not `varnish-8-persistent`)
-- [ ] New image has a service block in `helpers/images-docker-compose.yml` or `helpers/services-docker-compose.yml`
-- [ ] New image has matching test commands in the corresponding `helpers/TESTING_*_dockercompose.md`
-
-**Comment templates:**
-
-| Condition | Comment |
-|-----------|---------|
-| Target missing from `default` or service group | `Target is defined but not added to group "default" (and/or its service group). CI will silently skip it.` |
-| Variant lists commons in `contexts` | `Variant images should reference only their direct parent in \`contexts\`. Remove the commons entry unless this Dockerfile has an explicit \`FROM commons AS commons\` stage.` |
-| First-tier image missing commons context | `First-tier image is missing \`${LOCAL_REPO}/commons: target:commons\` in its bake \`contexts\`.` |
-| No test coverage | `New image has no compose entry or TESTING_*.md commands. Add coverage in helpers/.` |
-
-Do not speculate about test frameworks or suggest new testing approaches.
-
-## 8. Documentation
-
-**Checks:**
-- [ ] [README.md](../../README.md) updated when image behaviour, supported tags, or consumer-facing variants change
-- [ ] [.github/copilot-instructions.md](../../.github/copilot-instructions.md) updated when a recipe / workflow changes (e.g. new gotcha, new test pattern)
-- [ ] [architecture.md](../../architecture.md) updated when something *structural* changes (new image tier, new build variable, new pipeline stage, new convention)
-
-**Comment template:**
-
-```
-Documentation does not reflect this change. Update README / copilot-instructions / architecture as appropriate.
-```
-
-## 9. Lifecycle and backward compatibility
-
-The image lifecycle is: **active → EOL-labelled → removed (after ≥ 6 months)**. See [architecture.md §10](../../architecture.md#10-image-lifecycle).
-
-**Checks:**
-- [ ] No image removed without prior EOL labelling and a deprecation window
-- [ ] No published tag removed without an EOL marker on the image first
-- [ ] No default behaviour or `ENV` changed without a note in the PR description
-- [ ] No changes that break existing consumers without a clear upgrade path
-
-**Comment template:**
-
-```
-This change alters existing image behaviour. Confirm backward compatibility or document the breaking change and upgrade path.
-```
-
-Do not block internal refactors that do not affect external behaviour.
-
-## 10. End-of-life labelling
-
-Applies to PRs that mark an image as EOL or update an existing EOL marker. The full procedure is [Recipe 5 in copilot-instructions](../../.github/copilot-instructions.md#recipe-5--mark-an-image-as-end-of-life).
-
-**Checks:**
-- [ ] Both labels present, in the standard form:
-  ```dockerfile
-  LABEL sh.lagoon.image.deprecated.status="endoflife"
-  LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/<replacement>"
-  ```
-- [ ] The suggested replacement **already exists in this repo** as a built image
-- [ ] The replacement is the latest stable / longest-supported equivalent (not an arbitrary newer version)
-- [ ] The image continues to build and publish — only the labels are added, nothing is removed yet
-
-**Comment templates:**
-
-| Condition | Comment |
-|-----------|---------|
-| Suggested replacement missing or not built here | `Suggested replacement image is not built by this repo. Point to an image that exists in docker-bake.hcl.` |
-| Image gutted instead of labelled | `EOL marking should only add the two deprecation labels. Image must keep building and publishing for the deprecation window.` |
-
----
-
-## Review Output Format
-
-Every review **must** use this exact structure:
-
-```markdown
-## Summary
-- **Images affected:** [list affected image directories]
-- **Risk level:** low | medium | high
-- **Backward compatible:** yes | no | n/a
-
-## Blocking Issues
-[Issues that break builds, introduce security risks, or break backward compatibility.]
-[If none: "No blocking issues."]
-
-## Non-Blocking Suggestions
-[Grouped, concise suggestions. Omit section if none.]
-```
-
-**Rules:**
-- No praise or positive commentary
-- No filler text or restatement of the diff
-- No repeating the same comment across multiple files
+Keep this file concise and explanatory, and keep enforceable review checks in
+the instructions file.


### PR DESCRIPTION
This pull request introduces significant improvements to the PR review process documentation and automation for Lagoon Images. The most important changes are the addition of a canonical, machine-readable PR review policy for Copilot automation, updates to testing and validation guidance for image variants, and clarification of the end-of-life (EOL) policy and references throughout the documentation.

**Automated PR Review Policy:**

- Added `.github/instructions/pr-review.instructions.md`, a comprehensive, machine-consumed set of instructions for Copilot PR reviews. This file establishes enforceable checks and comment templates for image version pinning, layer construction, helper scripts, security, labeling, build wiring, documentation, and EOL handling. It also standardizes the required review output format.

**Documentation and Workflow Updates:**

- Updated `.github/copilot-instructions.md` to clarify its role as task-focused guidance, delegating enforceable review policy to the new machine-consumed instructions file. It now references `.github/instructions/pr-review.instructions.md` as canonical for automation, and provides clearer instructions on targeted validation for image variants. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L12-R25) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R157-R161) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L157-R176) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R186-R193)

**End-of-Life Policy Clarification:**

- Updated `architecture.md` to clarify that EOL image removal occurs after a minimum of 6 months (not just one release), and updated references to point to the new PR review instructions file. [[1]](diffhunk://#diff-4e03c430fc7f575c72fd989625acdc7d8d70fd20d3693c893d67d9dbd461ccdbL478-R478) [[2]](diffhunk://#diff-4e03c430fc7f575c72fd989625acdc7d8d70fd20d3693c893d67d9dbd461ccdbL490-R490) [[3]](diffhunk://#diff-4e03c430fc7f575c72fd989625acdc7d8d70fd20d3693c893d67d9dbd461ccdbL509-R509)

**Reference and Terminology Improvements:**

- Improved terminology in `architecture.md` to clarify the purpose of the PR review rubric as context/rationale, not just criteria.

These changes collectively improve the clarity, consistency, and enforceability of the PR review process for Lagoon Images.