### PR TITLE
Loosens version of mariadb 10.11 apks

### DIFF
--- a/images/mariadb/10.11.Dockerfile
+++ b/images/mariadb/10.11.Dockerfile
@@ -41,10 +41,10 @@ RUN apk update \
         bash \
         curl \
         gettext \
-        mariadb-client=10.11.16-r0 \
-        mariadb-common=10.11.16-r0 \
-        mariadb-server-utils=10.11.16-r0 \
-        mariadb=10.11.16-r0 \
+        mariadb-client=~10.11 \
+        mariadb-common=~10.11 \
+        mariadb-server-utils=~10.11 \
+        mariadb=~10.11 \
         mariadb-connector-c \
         net-tools \
         perl-doc \


### PR DESCRIPTION
This pull request updates the MariaDB package installation in the `images/mariadb/10.11.Dockerfile` to use version-matching syntax instead of pinning to a specific patch version. This change will allow the Docker image to automatically use the latest compatible 10.11.x versions of MariaDB and its related packages, improving maintainability and security.

**Dependency management:**

* Changed the installation of `mariadb-client`, `mariadb-common`, `mariadb-server-utils`, and `mariadb` from a fixed version (`10.11.16-r0`) to a version-matching pattern (`~10.11`), allowing for automatic updates within the 10.11 series.