### PR TITLE
Deprecation labels for node v20

### DIFF
--- a/images/node-builder/20.Dockerfile
+++ b/images/node-builder/20.Dockerfile
@@ -5,6 +5,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 LABEL org.opencontainers.image.description="Node.js 20 builder image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/node-20-builder"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-20"
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/node-24-builder"
 
 RUN apk update \
     && apk add --no-cache \

--- a/images/node-cli/20.Dockerfile
+++ b/images/node-cli/20.Dockerfile
@@ -5,6 +5,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 LABEL org.opencontainers.image.description="Node.js 20 cli image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/node-20-cli"
 LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-20"
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/node-24-cli"
 
 RUN apk add --no-cache bash \
         coreutils \

--- a/images/node/20.Dockerfile
+++ b/images/node/20.Dockerfile
@@ -6,6 +6,8 @@ LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-image
 LABEL org.opencontainers.image.description="Node.js 20 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/node-20"
 LABEL org.opencontainers.image.base.name="docker.io/node:20-alpine3.23"
+LABEL sh.lagoon.image.deprecated.status="endoflife"
+LABEL sh.lagoon.image.deprecated.suggested="docker.io/uselagoon/node-24"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION


### PR DESCRIPTION
This pull request adds deprecation labels to all Node.js 20-based Lagoon images, clearly marking them as end-of-life and suggesting migration to the corresponding Node.js 24 images. This will help users identify deprecated images and guide them towards supported alternatives.

closes #1773 