### PR TITLE
Adds node 26

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,6 +77,9 @@ group "default" {
     "node-24",
     "node-24-builder",
     "node-24-cli",
+    "node-26",
+    "node-26-builder",
+    "node-26-cli",
     "opensearch-2",
     "opensearch-3",
     "php-8-2-fpm",
@@ -178,7 +181,10 @@ group "node" {
     "node-22-cli",
     "node-24",
     "node-24-builder",
-    "node-24-cli"
+    "node-24-cli",
+    "node-26",
+    "node-26-builder",
+    "node-26-cli"
   ]
 }
 
@@ -491,6 +497,36 @@ target "node-24-cli" {
   }
   dockerfile = "24.Dockerfile"
   tags = tags("node-24-cli")
+}
+
+target "node-26" {
+  inherits = ["default"]
+  context = "images/node"
+  contexts = {
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+  dockerfile = "26.Dockerfile"
+  tags = tags("node-26")
+}
+
+target "node-26-builder" {
+  inherits = ["default"]
+  context = "images/node-builder"
+  contexts = {
+    "${LOCAL_REPO}/node-26": "target:node-26"
+  }
+  dockerfile = "26.Dockerfile"
+  tags = tags("node-26-builder")
+}
+
+target "node-26-cli" {
+  inherits = ["default"]
+  context = "images/node-cli"
+  contexts = {
+    "${LOCAL_REPO}/node-26": "target:node-26"
+  }
+  dockerfile = "26.Dockerfile"
+  tags = tags("node-26-cli")
 }
 
 target "opensearch-2" {

--- a/helpers/TESTING_base_images_dockercompose.md
+++ b/helpers/TESTING_base_images_dockercompose.md
@@ -39,6 +39,7 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-20
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-22
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-24
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep node-26
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-dev
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-2-prod
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep php-8-3-dev
@@ -301,6 +302,12 @@ docker compose exec -T node-24 sh -c "node -v" | grep "v24"
 
 # node-24 should be serving content
 docker compose exec -T commons sh -c "curl node-24:3000/test" | grep "v24"
+
+# node-26 should have Node 26
+docker compose exec -T node-26 sh -c "node -v" | grep "v26"
+
+# node-26 should be serving content
+docker compose exec -T commons sh -c "curl node-26:3000/test" | grep "v26"
 
 # ruby-3-2 should have Ruby 3.2
 docker compose exec -T ruby-3-2 sh -c "ruby -v" | grep "3.2"

--- a/helpers/images-docker-compose.yml
+++ b/helpers/images-docker-compose.yml
@@ -41,6 +41,17 @@ services:
         exec http-server -p 3000
         "]
 
+  node-26:
+    image: uselagoon/node-26:latest
+    ports:
+      - "3000"
+    user: root
+    command: ["sh", "-c", "
+        npm install -g http-server;
+        node -v | xargs > /app/test.html;
+        exec http-server -p 3000
+        "]
+
   php-8-2-dev:
     image: uselagoon/php-8.2-cli:latest
     ports:

--- a/images/node-builder/26.Dockerfile
+++ b/images/node-builder/26.Dockerfile
@@ -1,0 +1,32 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/node-26
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-builder/26.Dockerfile"
+LABEL org.opencontainers.image.description="Node.js 26 builder image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-26-builder"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-26"
+
+RUN apk update \
+    && apk add --no-cache \
+       libstdc++ \
+    && apk add --no-cache \
+       bash \
+       binutils-gold \
+       ca-certificates \
+       curl \
+       file \
+       g++ \
+       gcc \
+       gcompat \
+       git \
+       gnupg \
+       libgcc \
+       libpng-dev \
+       linux-headers \
+       make \
+       openssl \
+       python3 \
+       wget \
+    && rm -rf /var/cache/apk/*
+
+CMD ["/bin/docker-sleep"]

--- a/images/node-cli/26.Dockerfile
+++ b/images/node-cli/26.Dockerfile
@@ -1,0 +1,43 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/node-26
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node-cli/26.Dockerfile"
+LABEL org.opencontainers.image.description="Node.js 26 cli image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-26-cli"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/node-26"
+
+RUN apk add --no-cache bash \
+        coreutils \
+        findutils \
+        git \
+        gzip  \
+        mariadb-client=~11.4 \
+        mariadb-connector-c \
+        mongodb-tools \
+        openssh-client \
+        openssh-sftp-server \
+        patch \
+        postgresql-client \
+        procps \
+        unzip \
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+    && mkdir -p /home/.ssh \
+    && fix-permissions /home/
+
+COPY entrypoints /lagoon/entrypoints/
+
+# Make sure shells are not running forever
+RUN echo "source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+
+# Copy mariadb-client configuration.
+COPY mariadb-client.cnf /etc/my.cnf.d/
+RUN fix-permissions /etc/my.cnf.d/
+
+# SSH Key and Agent Setup
+COPY ssh_config /etc/ssh/ssh_config
+RUN sed -i '/# Deprecated: lagoon_cli.key/,+2d' /etc/ssh/ssh_config
+ENV SSH_AUTH_SOCK=/tmp/ssh-agent
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/bin/docker-sleep"]

--- a/images/node/26.Dockerfile
+++ b/images/node/26.Dockerfile
@@ -1,0 +1,51 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/commons AS commons
+FROM node:26.5-alpine3.23
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/node/26.Dockerfile"
+LABEL org.opencontainers.image.description="Node.js 26 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/node-26"
+LABEL org.opencontainers.image.base.name="docker.io/node:26-alpine3.23"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+ENV LAGOON=node
+
+RUN apk add --no-cache \
+        rsync \
+        tar
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home \
+    && fix-permissions /home \
+    && mkdir -p /app \
+    && fix-permissions /app
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+# Make sure Bower and NPM are allowed to be running as root
+RUN echo '{ "allow_root": true }' > /home/.bowerrc \
+    && echo 'unsafe-perm=true' > /home/.npmrc
+
+WORKDIR /app
+
+EXPOSE 3000
+
+# tells the local development environment on which port we are running
+ENV LAGOON_LOCALDEV_HTTP_PORT=3000
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["yarn", "run", "start"]

--- a/images/node/26.Dockerfile
+++ b/images/node/26.Dockerfile
@@ -36,10 +36,6 @@ ENV TMPDIR=/tmp \
     # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
     BASH_ENV=/home/.bashrc
 
-# Make sure Bower and NPM are allowed to be running as root
-RUN echo '{ "allow_root": true }' > /home/.bowerrc \
-    && echo 'unsafe-perm=true' > /home/.npmrc
-
 WORKDIR /app
 
 EXPOSE 3000


### PR DESCRIPTION
This pull request adds support for Node.js 26 images to the Lagoon Docker image build system. It introduces new Dockerfiles and build targets for the base, builder, and CLI variants of Node.js 26, updates the build configuration to include these images, and ensures that the test and compose files are updated to use and verify the new images.