### PR TITLE
Rollup: 9 green renovate PRs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
       with:
         config-file: .github/dependency-review-config.yaml

--- a/.github/workflows/ossf-analysis.yaml
+++ b/.github/workflows/ossf-analysis.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Run analysis
-      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
       with:
         results_file: results.sarif
         results_format: sarif

--- a/.github/workflows/ossf-analysis.yaml
+++ b/.github/workflows/ossf-analysis.yaml
@@ -26,6 +26,6 @@ jobs:
         # of the value entered here.
         publish_results: true
     - name: Upload SARIF results to code scanning
-      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         sarif_file: results.sarif

--- a/.github/workflows/ossf-analysis.yaml
+++ b/.github/workflows/ossf-analysis.yaml
@@ -14,7 +14,7 @@ jobs:
       # Needed for GitHub OIDC token if publish_results is true
       id-token: write
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Run analysis
       uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
       with:

--- a/images/mariadb/11.4.Dockerfile
+++ b/images/mariadb/11.4.Dockerfile
@@ -1,6 +1,6 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM mariadb:11.4.11-ubi9
+FROM mariadb:11.4.12-ubi9
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/11.4.Dockerfile"
 LABEL org.opencontainers.image.description="MariaDB 11.4 image optimised for running in Lagoon in production and locally"

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -46,7 +46,7 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.11 /usr/bin/install-php-extensions /usr/local/bin/
-COPY --from=ghcr.io/php/pie:1.4.8-bin /pie /usr/local/bin/
+COPY --from=ghcr.io/php/pie:1.4.9-bin /pie /usr/local/bin/
 
 RUN apk update \
     && apk upgrade --available musl \

--- a/images/php-fpm/8.2.Dockerfile
+++ b/images/php-fpm/8.2.Dockerfile
@@ -133,7 +133,7 @@ RUN apk update \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=12.7.0.36
+ENV NEWRELIC_VERSION=12.9.0.38
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -46,7 +46,7 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.11 /usr/bin/install-php-extensions /usr/local/bin/
-COPY --from=ghcr.io/php/pie:1.4.8-bin /pie /usr/local/bin/
+COPY --from=ghcr.io/php/pie:1.4.9-bin /pie /usr/local/bin/
 
 RUN apk update \
     && apk upgrade --available musl \

--- a/images/php-fpm/8.3.Dockerfile
+++ b/images/php-fpm/8.3.Dockerfile
@@ -133,7 +133,7 @@ RUN apk update \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=12.7.0.36
+ENV NEWRELIC_VERSION=12.9.0.38
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \

--- a/images/php-fpm/8.4.Dockerfile
+++ b/images/php-fpm/8.4.Dockerfile
@@ -46,7 +46,7 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.11 /usr/bin/install-php-extensions /usr/local/bin/
-COPY --from=ghcr.io/php/pie:1.4.8-bin /pie /usr/local/bin/
+COPY --from=ghcr.io/php/pie:1.4.9-bin /pie /usr/local/bin/
 
 RUN apk update \
     && apk upgrade --available musl \

--- a/images/php-fpm/8.4.Dockerfile
+++ b/images/php-fpm/8.4.Dockerfile
@@ -133,7 +133,7 @@ RUN apk update \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=12.7.0.36
+ENV NEWRELIC_VERSION=12.9.0.38
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \

--- a/images/php-fpm/8.5.Dockerfile
+++ b/images/php-fpm/8.5.Dockerfile
@@ -46,7 +46,7 @@ COPY php-fpm.d/www.conf php-fpm.d/global.conf /usr/local/etc/php-fpm.d/
 COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY blackfire.ini /usr/local/etc/php/conf.d/blackfire.disable
 COPY --from=docker.io/mlocati/php-extension-installer:2.11 /usr/bin/install-php-extensions /usr/local/bin/
-COPY --from=ghcr.io/php/pie:1.4.8-bin /pie /usr/local/bin/
+COPY --from=ghcr.io/php/pie:1.4.9-bin /pie /usr/local/bin/
 
 RUN apk update \
     && apk upgrade --available musl \

--- a/images/php-fpm/8.5.Dockerfile
+++ b/images/php-fpm/8.5.Dockerfile
@@ -133,7 +133,7 @@ RUN apk update \
 # New Relic PHP Agent.
 # @see https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/
 # @see https://docs.newrelic.com/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-ENV NEWRELIC_VERSION=12.7.0.36
+ENV NEWRELIC_VERSION=12.9.0.38
 RUN mkdir -p /tmp/newrelic && cd /tmp/newrelic \
     && wget https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz \
     && gzip -dc newrelic-php5-${NEWRELIC_VERSION}-linux-musl.tar.gz | tar --strip-components=1 -xf - \

--- a/images/redis/7.Dockerfile
+++ b/images/redis/7.Dockerfile
@@ -1,7 +1,7 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 # Held at alpine3.21 until EOL
-FROM redis:7.2.14-alpine3.21
+FROM redis:7.4.10-alpine3.21
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile"
 LABEL org.opencontainers.image.description="Redis 7 image optimised for running in Lagoon in production and locally"

--- a/images/redis/8.Dockerfile
+++ b/images/redis/8.Dockerfile
@@ -1,6 +1,6 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM redis:8.8.0-alpine3.23
+FROM redis:8.8.1-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile"
 LABEL org.opencontainers.image.description="Redis 8 image optimised for running in Lagoon in production and locally"

--- a/images/ruby/4.0.Dockerfile
+++ b/images/ruby/4.0.Dockerfile
@@ -1,6 +1,6 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
-FROM ruby:4.0.5-alpine3.23
+FROM ruby:4.0.6-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/4.0.Dockerfile"
 LABEL org.opencontainers.image.description="Ruby 4.0 image optimised for running in Lagoon in production and locally"


### PR DESCRIPTION
Combines the renovate PRs whose checks are all green into one branch so they can be merged (and CI-tested) as a single unit.

Includes the actual head commits of:
#1723, #1763, #1776, #1777, #1779, #1780, #1781, #1783, #1784

> [!IMPORTANT]
> Merge this PR with a **merge commit** (not squash/rebase). That way the original PR head commits land on main and GitHub automatically marks all 9 PRs above as merged. Squashing would leave them open.

Not included:
- openresty update (PR 1738) — deliberately excluded so `images/nginx/Dockerfile` is untouched here; it bumps the nginx core 1.29 → 1.31 and will be tested in its own scope.
- #1782 (redis 7.2.15) — superseded by #1784 (redis 7.4.10), same file; can be closed.
- All PRs with failing checks — to be addressed separately.

All FROM/ENV changes verified to stay within each Dockerfile's pinned version line.