### PR TITLE
Migrate docker/actions dependency updates from renovate to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/images/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    labels:
+      - "dependencies"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
+    ignore:
+      # One Dockerfile per pinned major.minor (e.g. mariadb/10.6.Dockerfile,
+      # php-fpm/8.2.Dockerfile) - patch updates only
+      - dependency-name: "mariadb"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "mysql"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "php"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "ruby"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "alpine"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # One Dockerfile per pinned major (e.g. postgres/14.Dockerfile stays on
+      # postgres 14) - minor and patch updates only
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "opensearchproject/opensearch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "postgres"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "redis"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "solr"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "valkey/valkey"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "varnish"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,9 @@
   "separateMajorMinor": true,
   "separateMinorPatch": true,
   "separateMultipleMajor": true,
+  "enabledManagers": [
+    "custom.regex"
+  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -223,71 +226,8 @@
       ]
     },
     {
-      "enabled": true,
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "matchPackageNames": [
-        "mariadb",
-        "mysql",
-        "php",
-        "python",
-        "ruby"
-      ]
-    },
-    {
-      "enabled": true,
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "openresty/openresty"
-      ],
-      "versioning": "regex:^(\\d)\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<compatibility>.*)$"
-    },
-    {
-      "draftPR": true,
-      "groupName": "Draft major and minor update PRs - packages update only patch",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "matchPackageNames": [
-        "mariadb",
-        "mysql",
-        "php",
-        "python",
-        "ruby"
-      ]
-    },
-    {
-      "enabled": true,
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "matchPackageNames": [
-        "node",
-        "opensearchproject/opensearch",
-        "postgres",
-        "redis",
-        "solr",
-        "valkey/valkey",
-        "varnish"
-      ]
-    },
-    {
-      "draftPR": true,
-      "groupName": "Draft major release PRs - packages update only minor",
+      "enabled": false,
+      "groupName": "Disable VARNISH_VERSION major updates - varnish/6.Dockerfile stays on v6",
       "matchDatasources": [
         "docker"
       ],
@@ -295,26 +235,7 @@
         "major"
       ],
       "matchPackageNames": [
-        "node",
-        "opensearchproject/opensearch",
-        "postgres",
-        "redis",
-        "solr",
-        "valkey/valkey",
         "varnish"
-      ]
-    },
-    {
-      "enabled": false,
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "matchPackageNames": [
-        "alpine"
       ]
     },
     {


### PR DESCRIPTION
Aligns this repo with the dependabot setup used across our other orgs.

**Dependabot takes over** (`.github/dependabot.yml`):
- Dockerfile `FROM` lines across `images/*` (weekly)
- GitHub Actions workflow versions (weekly)
- `ignore` rules keep version-pinned Dockerfiles on their line:
  - postgres, node, redis, solr, valkey, varnish, opensearch: majors blocked (e.g. `postgres/14.Dockerfile` stays on 14.x)
  - mariadb, mysql, php, python, ruby, alpine: majors **and** minors blocked (files pin major.minor, e.g. `php-fpm/8.2.Dockerfile`)
- patch and minor updates land as two grouped PRs instead of one PR per image

**Renovate stays, slimmed** to only what dependabot has no equivalent for — the custom regex managers: pecl extensions (apcu/imagick/redis/xdebug/yaml), `NEWRELIC_VERSION`/`BLACKFIRE_VERSION`/`OPENRESTY_VERSION`/`VARNISH_VERSION` env vars, and phar downloads. All standard renovate managers are disabled via `enabledManagers`.

**No auto-merge in this repo**: every dependency PR (dependabot and renovate alike) requires human review and a manual merge — same as before, neither bot has automerge configured here.

Behavior changes to be aware of:
- renovate opened *draft PRs* for major updates as a heads-up; dependabot's ignore is silent
- dependabot only targets `main` — the `testing/*` base branches keep only regex-manager coverage