### PR TITLE
Move valkey updates from dependabot to renovate custom managers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "solr"
         update-types: ["version-update:semver-major"]
+      # valkey is handled by renovate custom managers so the alpine tag
+      # suffix can be bumped together with the valkey version
       - dependency-name: "valkey/valkey"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "varnish"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"

--- a/renovate.json
+++ b/renovate.json
@@ -144,6 +144,29 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/(^|/)valkey/.*\\.Dockerfile$/"
+      ],
+      "matchStrings": [
+        "FROM valkey/valkey:(?<currentValue>[\\d.]+)-alpine[\\d.]+"
+      ],
+      "depNameTemplate": "valkey/valkey",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)valkey/.*\\.Dockerfile$/"
+      ],
+      "matchStrings": [
+        "FROM valkey/valkey:[\\d.]+-alpine(?<currentValue>[\\d.]+)"
+      ],
+      "depNameTemplate": "valkey-alpine-base",
+      "packageNameTemplate": "alpine",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/)varnish/6\\.Dockerfile$/"
       ],
       "matchStrings": [
@@ -236,6 +259,22 @@
       ],
       "matchPackageNames": [
         "varnish"
+      ]
+    },
+    {
+      "groupName": "valkey",
+      "matchFileNames": [
+        "images/valkey/**"
+      ]
+    },
+    {
+      "enabled": false,
+      "groupName": "Disable valkey major updates - one Dockerfile per pinned major",
+      "matchDepNames": [
+        "valkey/valkey"
+      ],
+      "matchUpdateTypes": [
+        "major"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -150,7 +150,8 @@
         "FROM valkey/valkey:(?<currentValue>[\\d.]+)-alpine[\\d.]+"
       ],
       "depNameTemplate": "valkey/valkey",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)-alpine[\\d.]+$"
     },
     {
       "customType": "regex",
@@ -162,7 +163,8 @@
       ],
       "depNameTemplate": "valkey-alpine-base",
       "packageNameTemplate": "alpine",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Why

Valkey 9.1.1 was released, but no update PR appeared. Cause: upstream published 9.1.1 only with an `alpine3.24` tag suffix, and our Dockerfile pins `valkey/valkey:9.1.0-alpine3.23`. Dependabot treats the `-alpine3.23` suffix as a hard compatibility constraint, so with no `9.1.1-alpine3.23` tag on Docker Hub it (correctly, per its design) finds nothing to offer. Renovate's docker manager behaves the same way — the suffix pin silently freezes the image.

## What

- **renovate.json**: two custom regex managers over `images/valkey/*.Dockerfile` that split the tag into two dependencies — the valkey version (tracked against `valkey/valkey` docker tags) and the alpine suffix (tracked against `alpine` docker tags). A `groupName: valkey` rule scoped to `images/valkey/**` merges both into a single PR. Valkey major updates are disabled to keep the one-Dockerfile-per-major convention.
- **.github/dependabot.yml**: fully ignore `valkey/valkey` so the two bots don't open competing PRs.

Next renovate run should open one PR taking the pin to `valkey/valkey:9.1.1-alpine3.24`.

## Caveats

- Renovate resolves each part independently and never verifies the *composed* tag exists — if the parts ever desync, the image build in CI on the renovate PR is the safety net.
- This lets valkey's alpine base auto-bump on alpine minor releases, unlike the other images where alpine minors are held for deliberate bulk bumps (e.g. #1555).