### PR TITLE
build: add mariadb-11.8 image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -63,6 +63,7 @@ group "default" {
     "mariadb-10-11",
     "mariadb-10-11-drupal",
     "mariadb-11-4",
+    "mariadb-11-8",
     "mariadb-12-3",
     "mongo-4",
     "mysql-8-0",
@@ -141,6 +142,7 @@ group "mariadb" {
     "mariadb-10-11",
     "mariadb-10-11-drupal",
     "mariadb-11-4",
+    "mariadb-11-8",
     "mariadb-12-3"
   ]
 }
@@ -350,6 +352,16 @@ target "mariadb-11-4" {
   }
   dockerfile = "11.4.Dockerfile"
   tags = tags("mariadb-11.4")
+}
+
+target "mariadb-11-8" {
+  inherits = ["default"]
+  context = "images/mariadb"
+  contexts = {
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+  dockerfile = "11.8.Dockerfile"
+  tags = tags("mariadb-11.8")
 }
 
 target "mariadb-12-3" {

--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -25,6 +25,7 @@ docker compose build && docker compose up -d
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-6:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-10-11:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-11-4:3306 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-11-8:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mariadb-12-3:3306 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mongo-4:27017 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://mysql-8-0:3306 -timeout 1m
@@ -55,6 +56,8 @@ Run the following commands to validate things are rolling as they should.
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep commons
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mariadb-10-6
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mariadb-10-11
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mariadb-11-4
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mariadb-11-8
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mariadb-12-3
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mongo-4
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep mysql-8-0
@@ -145,6 +148,28 @@ docker compose exec -T mariadb-11-4 sh -c "mariadb -D lagoon -u lagoon --passwor
 # mariadb-11-4 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb?service=mariadb-11-4" | grep "SERVICE_HOST=11.4"
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb?service=mariadb-11-4" | grep "LAGOON_TEST_VAR=all-images"
+
+# mariadb-11-8 should be version 11.8 client
+docker compose exec -T mariadb-11-8 sh -c "mariadb -V" | grep "11.8"
+
+# mariadb-11-8 should be version 11.8 server
+docker compose exec -T mariadb-11-8 sh -c "echo U0hPVyB2YXJpYWJsZXM7 | base64 -d > /tmp/showvariables.sql"
+docker compose exec -T mariadb-11-8 sh -c "mariadb < /tmp/showvariables.sql" | grep "version" | grep "11.8"
+
+# mariadb-11-8 should have performance schema and slow logging enabled
+docker compose exec -T mariadb-11-8 sh -c "echo U0hPVyBHTE9CQUwgVkFSSUFCTEVTOw== | base64 -d > /tmp/showglobalvars.sql"
+docker compose exec -T mariadb-11-8 sh -c "mariadb -D lagoon -u lagoon --password=lagoon < /tmp/showglobalvars.sql" | grep "performance_schema" | grep "ON"
+docker compose exec -T mariadb-11-8 sh -c "mariadb -D lagoon -u lagoon --password=lagoon < /tmp/showglobalvars.sql" | grep "slow_query_log" | grep "ON"
+docker compose exec -T mariadb-11-8 sh -c "mariadb -D lagoon -u lagoon --password=lagoon < /tmp/showglobalvars.sql" | grep "long_query_time" | grep "30"
+docker compose exec -T mariadb-11-8 sh -c "mariadb -D lagoon -u lagoon --password=lagoon < /tmp/showglobalvars.sql" | grep "log_slow_rate_limit" | grep "5"
+
+# mariadb-11-8 should use default credentials
+docker compose exec -T mariadb-11-8 sh -c "echo U0hPVyBkYXRhYmFzZXM7 | base64 -d > /tmp/showdatabases.sql"
+docker compose exec -T mariadb-11-8 sh -c "mariadb -D lagoon -u lagoon --password=lagoon < /tmp/showdatabases.sql" | grep lagoon
+
+# mariadb-11-8 should be able to read/write data
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb?service=mariadb-11-8" | grep "SERVICE_HOST=11.8"
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/mariadb?service=mariadb-11-8" | grep "LAGOON_TEST_VAR=all-images"
 
 # mariadb-12-3 should be version 12.3 client
 docker compose exec -T mariadb-12-3 sh -c "mariadb -V" | grep "12.3"

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -44,6 +44,17 @@ services:
       - MARIADB_LOG_SLOW_RATE_LIMIT=5
     << : *default-user # uses the defined user from top
 
+  mariadb-11-8:
+    image: uselagoon/mariadb-11.8:latest
+    ports:
+      - "3306"
+    environment:
+      - MARIADB_PERFORMANCE_SCHEMA=true
+      - MARIADB_LOG_SLOW=true
+      - MARIADB_LONG_QUERY_TIME=30
+      - MARIADB_LOG_SLOW_RATE_LIMIT=5
+    << : *default-user
+
   mariadb-12-3:
     image: uselagoon/mariadb-12.3:latest
     ports:

--- a/images/mariadb/11.8.Dockerfile
+++ b/images/mariadb/11.8.Dockerfile
@@ -1,0 +1,89 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/commons AS commons
+FROM mariadb:11.8.8-ubi9
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/11.8.Dockerfile"
+LABEL org.opencontainers.image.description="MariaDB 11.8 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/mariadb-11.8"
+LABEL org.opencontainers.image.base.name="docker.io/mariadb:11.8-ubi9"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+ENV LAGOON=mariadb
+
+USER root
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /home /home
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+ENV BACKUPS_DIR="/var/lib/mysql/backup"
+
+ENV MARIADB_DATABASE=lagoon \
+    MARIADB_USER=lagoon \
+    MARIADB_PASSWORD=lagoon \
+    MARIADB_ROOT_PASSWORD=Lag00n
+
+RUN printf "[main]\nexcludepkgs=MariaDB*" > /etc/dnf/dnf.conf \
+    && microdnf install -y epel-release \
+    && microdnf install -y \
+        gettext \
+        openssh-clients \
+        pwgen \
+        rsync \
+        tar \
+        wget \
+    && microdnf clean all \
+    && rm -rf /var/lib/mysql/* /etc/mysql/ /etc/my.cnf* \
+    && curl -sSL https://raw.githubusercontent.com/major/MySQLTuner-perl/master/mysqltuner.pl -o mysqltuner.pl
+
+RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -sL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${architecture} -o /sbin/tini && chmod a+x /sbin/tini
+
+COPY entrypoints/ /lagoon/entrypoints/
+COPY mysql-backup.sh /lagoon/
+COPY my.11.cnf /etc/mysql/my.cnf
+
+RUN rm /lagoon/entrypoints/9999-mariadb-init.10.bash \
+    && mv /lagoon/entrypoints/9999-mariadb-init.11.bash /lagoon/entrypoints/9999-mariadb-init.bash \
+    && echo "!include /etc/mysql/my.cnf" >> /etc/my.cnf
+
+RUN for i in /var/run/mysqld /run/mariadb /run/mysqld /var/lib/mysql /etc/mysql/conf.d /docker-entrypoint-initdb.d /home; \
+    do mkdir -p $i; chown mysql $i; /bin/fix-permissions $i; \
+    done
+
+COPY root/usr/share/container-scripts/mysql/readiness-probe.sh /usr/share/container-scripts/mysql/readiness-probe.sh
+RUN /bin/fix-permissions /usr/share/container-scripts/mysql/ \
+    && /bin/fix-permissions /etc/mysql
+
+RUN touch /var/log/mariadb-slow.log && /bin/fix-permissions /var/log/mariadb-slow.log \
+    && touch /var/log/mariadb-queries.log && /bin/fix-permissions /var/log/mariadb-queries.log
+
+# We cannot start mysql as root, we add the user mysql to the group root and
+# ensure that the gid and uid match the previous image releases and then we
+# change the user of the Docker Image to this user.
+RUN groupmod -o -g 101 mysql \
+    && usermod -u 100 mysql \
+    && usermod -a -G root mysql
+
+USER mysql
+ENV USER_NAME=mysql
+
+WORKDIR /var/lib/mysql
+EXPOSE 3306
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+CMD ["mariadbd"]


### PR DESCRIPTION
## Summary

Adds a MariaDB 11.8 LTS image (from `mariadb:11.8.8-ubi9`), alongside the existing 10.6/10.11/11.4 images.

MariaDB 11.8 is the current LTS release ([supported until June 2028](https://mariadb.org/11-8-is-lts/)).

- `images/mariadb/11.8.Dockerfile` — mirrors the 11.4 image (ubi9 base, `my.11.cnf`, 11.x init entrypoint)
- No `-drupal` variant, matching the 11.4 precedent
- New `mariadb-11-8` bake target, added to the `default` and `mariadb` groups
- Compose service + test steps in the helpers (also adds the missing `docker ps` check lines for mariadb-11-4)

## Testing

- `docker buildx bake mariadb-11-8` builds successfully
- Container boots and `SELECT VERSION();` as the default `lagoon` user returns `11.8.8-MariaDB`