### PR TITLE
build: add postgres-18 image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -102,6 +102,8 @@ group "default" {
     "postgres-16-drupal",
     "postgres-17",
     "postgres-17-drupal",
+    "postgres-18",
+    "postgres-18-drupal",
     "python-3-10",
     "python-3-11",
     "python-3-12",
@@ -225,6 +227,8 @@ group "postgres" {
     "postgres-16-drupal",
     "postgres-17",
     "postgres-17-drupal",
+    "postgres-18",
+    "postgres-18-drupal",
   ]
 }
 
@@ -747,6 +751,26 @@ target "postgres-17-drupal" {
   }
   dockerfile = "17.Dockerfile"
   tags = tags("postgres-17-drupal")
+}
+
+target "postgres-18" {
+  inherits = ["default"]
+  context = "images/postgres"
+  contexts = {
+    "${LOCAL_REPO}/commons": "target:commons"
+  }
+  dockerfile = "18.Dockerfile"
+  tags = tags("postgres-18")
+}
+
+target "postgres-18-drupal" {
+  inherits = ["default"]
+  context = "images/postgres-drupal"
+  contexts = {
+    "${LOCAL_REPO}/postgres-18": "target:postgres-18"
+  }
+  dockerfile = "18.Dockerfile"
+  tags = tags("postgres-18-drupal")
 }
 
 target "python-3-10" {

--- a/helpers/TESTING_service_images_dockercompose.md
+++ b/helpers/TESTING_service_images_dockercompose.md
@@ -35,6 +35,7 @@ docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp:/
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-15:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-16:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-17:5432 -timeout 1m
+docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://postgres-18:5432 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://rabbitmq:15672 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-7:6379 -timeout 1m
 docker run --rm --net all-images_default jwilder/dockerize dockerize -wait tcp://redis-8:6379 -timeout 1m
@@ -64,6 +65,7 @@ docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep 
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-15
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-16
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-17
+docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep postgres-18
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep rabbitmq
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-7
 docker ps --filter label=com.docker.compose.project=all-images | grep Up | grep redis-8
@@ -282,6 +284,21 @@ docker compose exec -T postgres-17 bash -c "psql -U lagoon -d lagoon < /tmp/list
 # postgres-17 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres?service=postgres-17" | grep "SERVICE_HOST=PostgreSQL 17"
 docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres?service=postgres-17" | grep "LAGOON_TEST_VAR=all-images"
+
+# postgres-18 should be version 18 client
+docker compose exec -T postgres-18 bash -c "psql --version" | grep "psql" | grep "18."
+
+# postgres-18 should be version 18 server
+docker compose exec -T postgres-18 bash -c "echo U0VMRUNUIHZlcnNpb24oKTs= | base64 -d > /tmp/selectversion.sql"
+docker compose exec -T postgres-18 bash -c "psql -U lagoon -d lagoon < /tmp/selectversion.sql" | grep "PostgreSQL" | grep "18."
+
+# postgres-18 should have lagoon database
+docker compose exec -T postgres-18 bash -c "echo XGwrIGxhZ29vbg== | base64 -d > /tmp/listlagoon.sql"
+docker compose exec -T postgres-18 bash -c "psql -U lagoon -d lagoon < /tmp/listlagoon.sql" | grep "lagoon"
+
+# postgres-18 should be able to read/write data
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres?service=postgres-18" | grep "SERVICE_HOST=PostgreSQL 18"
+docker compose exec -T commons sh -c "curl -kL http://internal-services-test:3000/postgres?service=postgres-18" | grep "LAGOON_TEST_VAR=all-images"
 
 # rabbitmq should have RabbitMQ running 3.10
 docker compose exec -T rabbitmq sh -c "rabbitmqctl version" | grep 3.10

--- a/helpers/services-docker-compose.yml
+++ b/helpers/services-docker-compose.yml
@@ -111,6 +111,12 @@ services:
       - "5432"
     << : *default-user
 
+  postgres-18:
+    image: uselagoon/postgres-18:latest
+    ports:
+      - "5432"
+    << : *default-user
+
   rabbitmq:
     image: uselagoon/rabbitmq:latest
     ports:

--- a/images/postgres-drupal/18.Dockerfile
+++ b/images/postgres-drupal/18.Dockerfile
@@ -1,0 +1,15 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/postgres-18
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres-drupal/18.Dockerfile"
+LABEL org.opencontainers.image.description="PostgreSQL 18 image optimised for Drupal workloads running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-18-drupal"
+LABEL org.opencontainers.image.base.name="docker.io/uselagoon/postgres-18"
+
+# change log_min_error_statement and log_min_messages from `error` to `log` as drupal is prone to cause some errors which are all logged (yes `log` is a less verbose mode than `error`)
+RUN sed -i "s/#log_min_error_statement = error/log_min_error_statement = log/" /usr/local/share/postgresql/postgresql.conf.sample \
+    && sed -i "s/#log_min_messages = warning/log_min_messages = log/" /usr/local/share/postgresql/postgresql.conf.sample
+
+ENV POSTGRES_PASSWORD=drupal \
+    POSTGRES_USER=drupal \
+    POSTGRES_DB=drupal

--- a/images/postgres/18.Dockerfile
+++ b/images/postgres/18.Dockerfile
@@ -1,0 +1,52 @@
+ARG LOCAL_REPO
+FROM ${LOCAL_REPO:-lagoon}/commons AS commons
+FROM postgres:18.4-alpine3.23
+
+LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/18.Dockerfile"
+LABEL org.opencontainers.image.description="PostgreSQL 18 image optimised for running in Lagoon in production and locally"
+LABEL org.opencontainers.image.title="uselagoon/postgres-18"
+LABEL org.opencontainers.image.base.name="docker.io/postgres:18-alpine3.23"
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+ENV LAGOON=postgres
+
+# Copy commons files
+COPY --from=commons /lagoon /lagoon
+COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
+COPY --from=commons /sbin/tini /sbin/
+COPY --from=commons /home /home
+
+ENV TMPDIR=/tmp \
+    TMP=/tmp \
+    HOME=/home \
+    # When Bash is invoked via `sh` it behaves like the old Bourne Shell and sources a file that is given in `ENV`
+    ENV=/home/.bashrc \
+    # When Bash is invoked as non-interactive (like `bash -c command`) it sources a file that is given in `BASH_ENV`
+    BASH_ENV=/home/.bashrc
+
+RUN apk update \
+    && apk add --no-cache \
+        rsync \
+        tar \
+    && rm -rf /var/cache/apk/*
+
+RUN fix-permissions /etc/passwd \
+    && mkdir -p /home
+
+COPY postgres-backup.sh /lagoon/
+
+RUN echo -e "local all all md5\nhost  all  all 0.0.0.0/0 md5" >> /usr/local/share/postgresql/pg_hba.conf
+
+# PGDATA is kept at the pre-18 path so Lagoon persistent-volume mounts keep working;
+# the upstream postgres:18 image moved its default to /var/lib/postgresql/18/docker
+ENV PGUSER=postgres \
+    POSTGRES_PASSWORD=lagoon \
+    POSTGRES_USER=lagoon \
+    POSTGRES_DB=lagoon \
+    PGDATA=/var/lib/postgresql/data/pgdata
+
+# Postgresql entrypoint file needs bash, so start the entrypoints with bash
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.bash"]
+CMD ["/usr/local/bin/docker-entrypoint.sh", "postgres"]


### PR DESCRIPTION
## Summary

Adds a PostgreSQL 18 image (from `postgres:18.4-alpine3.23`), alongside the existing 14–17 images. PostgreSQL 18 has been GA since [September 2025](https://www.postgresql.org/about/news/postgresql-18-released-3142/).

- `images/postgres/18.Dockerfile` — mirrors the 17 image
- `PGDATA` is deliberately kept at `/var/lib/postgresql/data/pgdata`: the upstream postgres:18 image moved its default data dir to `/var/lib/postgresql/18/docker`, but keeping the old path preserves Lagoon's persistent-volume mount behaviour
- New `postgres-18` bake target, added to the `default` and `postgres` groups
- Compose service + test steps in the helpers

### No `postgres-18-drupal` variant

Following the MariaDB 11.4 approach in #1269 (see also the [25.5.0 release notes](https://github.com/uselagoon/lagoon-images/releases/tag/25.5.0)), there is no Drupal-specific variant. The `postgres-*-drupal` images only differed from the base in two ways, both of which can be set without a separate image:

- **Credentials**: set `POSTGRES_DB`, `POSTGRES_USER` and `POSTGRES_PASSWORD` to `drupal` in the service's `environment` block for local backwards compatibility.
- **Log levels**: the drupal variant changed `log_min_error_statement` and `log_min_messages` to `log` to quieten Drupal's noisy queries. This dates back to the original 2018 postgres-drupal image with no further history. If needed, pass it on the command, e.g. `command: ["postgres", "-c", "log_min_messages=log", "-c", "log_min_error_statement=log"]`.

```yaml
  postgres:
    image: uselagoon/postgres-18:latest
    labels:
      lagoon.type: postgres
    ports:
      - "5432"
    << : *default-user
    environment:
      << : *default-environment
      POSTGRES_DB: drupal
      POSTGRES_USER: drupal
      POSTGRES_PASSWORD: drupal
```

## Testing

- `docker buildx bake postgres-18` builds successfully
- Container boots with the default lagoon DB/credentials and `SELECT version();` returns `PostgreSQL 18.4`
