### PR TITLE
Downgrade Redis to 7.2.16 and clarify license terms

### DIFF
--- a/images/redis/7.Dockerfile
+++ b/images/redis/7.Dockerfile
@@ -7,7 +7,7 @@ FROM redis:7.2.16-alpine3.21
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile"
 LABEL org.opencontainers.image.description="Redis 7 image optimised for running in Lagoon in production and locally"
 LABEL org.opencontainers.image.title="uselagoon/redis-7"
-LABEL org.opencontainers.image.base.name="docker.io/redis:7-alpine3.21"
+LABEL org.opencontainers.image.base.name="docker.io/redis:7.2-alpine3.21"
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION

--- a/images/redis/7.Dockerfile
+++ b/images/redis/7.Dockerfile
@@ -1,7 +1,8 @@
 ARG LOCAL_REPO
 FROM ${LOCAL_REPO:-lagoon}/commons AS commons
 # Held at alpine3.21 until EOL
-FROM redis:7.4.10-alpine3.21
+# Held at redis:7.2.x under BSD-3-Clause license
+FROM redis:7.2.16-alpine3.21
 
 LABEL org.opencontainers.image.source="https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile"
 LABEL org.opencontainers.image.description="Redis 7 image optimised for running in Lagoon in production and locally"

--- a/renovate.json
+++ b/renovate.json
@@ -251,6 +251,12 @@
       ]
     },
     {
+      "groupName": "Redis OSS",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["redis"],
+      "allowedVersions": "!/^7\\.4/"
+    },
+    {
       "groupName": "valkey",
       "matchFileNames": [
         "images/valkey/**"

--- a/renovate.json
+++ b/renovate.json
@@ -251,10 +251,11 @@
       ]
     },
     {
-      "groupName": "Redis OSS",
+      "groupName": "Redis 7.2 OSS",
       "matchDatasources": ["docker"],
+      "matchFileNames": ["images/redis/7.Dockerfile"],
       "matchPackageNames": ["redis"],
-      "allowedVersions": "!/^7\\.4/"
+      "allowedVersions": "/^7\\.2\\./"
     },
     {
       "groupName": "valkey",


### PR DESCRIPTION
Redis version 7.4.x was released under a non-open-source license, and was deemed not suitable for repackaging and redistributing in Lagoon images. (ref https://github.com/redis/redis/tree/7.4.0?tab=License-1-ov-file), hence the switch to support Valkey.
* Redis version 7.2.x and previous are available under a BSD-3-Clause license
* Redis version 8.0.x and onwards are available under an AGPLv3 license

This PR reverts the change made in https://github.com/uselagoon/lagoon-images/pull/1787 to the latest 7.2.16 image, and adds an exclusion clause into renovate.json to ignore 7.4.x as an upgrade target.